### PR TITLE
ログアウト機能実装&ログイン後のリダイレクト先変更

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -27,7 +27,24 @@ class LoginController extends Controller
      * @var string
      */
     
-    protected $redirectTo = RouteServiceProvider::HOME;
+    // protected $redirectTo = RouteServiceProvider::HOME;
+
+    // ▼admin_flgでログイン後のページ遷移を振り分ける
+    protected  function redirectTo()
+    {
+        $admin_flg = $this->guard()->user()->admin_flg;
+        if($admin_flg == 1){
+            return '/admin/setting/';
+        }else if($admin_flg == 0){
+            return '/staff/select-role/';
+        }
+    }
+
+    // ▼ログアウト後の遷移先
+    protected function loggedOut(\Illuminate\Http\Request $request)
+    {
+        return redirect('/login');
+    }
 
     /**
      * Create a new controller instance.
@@ -39,8 +56,8 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
     }
 
-    // loginに必要な項目を追記
+    // ▼loginに必要な項目を追記
     public function username(){
       return 'login_id';
-  }
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        // // adminのみ許可
+        // \Gate::define('admin', function ($user) {
+        //     return ($user->admin_flg == 1);
+        // });
     }
 }

--- a/resources/js/components/items/HeaderComponent.vue
+++ b/resources/js/components/items/HeaderComponent.vue
@@ -17,6 +17,7 @@
             <v-btn icon>
                 <v-icon>mdi-magnify</v-icon>
             </v-btn>
+            <span @click="logout" style="cursor: pointer;">ログアウト</span>
 
             <v-menu left bottom>
                 <template v-slot:activator="{ on, attrs }">
@@ -207,7 +208,17 @@ export default {
     },
     created() {},
     computed: {},
-    methods: {}
+    methods: {
+        //ログアウト
+        logout: function() {
+            axios
+                .post("/logout")
+                .then(res => {
+                    location.href = "/";
+                })
+                .catch(err => console.log(err));
+        }
+    }
 };
 </script>
 


### PR DESCRIPTION
# ログアウト機能
- ヘッダーに仮設置してます
- ログアウト後は'/login'に飛ばします

#  ログイン後のリダイレクト先
- ユーザーテーブルのadmin_flgを参照して、振り分けてます
- laravelのキャッシュが残ってると上手くリダイレクトしてくれないみたいで、まだ不安定です。別途修正が必要かもです。