### PR TITLE
API命名変更

### DIFF
--- a/app/Http/Controllers/Api/AttendancesController.php
+++ b/app/Http/Controllers/Api/AttendancesController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/HospitalsController.php
+++ b/app/Http/Controllers/Api/HospitalsController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/PatientsController.php
+++ b/app/Http/Controllers/Api/PatientsController.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;
 use DB;
 use App\Patient;
-    
+
   class PatientsController extends Controller
   {
      //患者表示
-    public function Allpatients(){ 
+    public function getAllPatients(){ 
     // $wardId= Auth::ward_id();
      // $patients = Patient::where('ward_id','=', $wardId)
     // ->orderBy('room', 'asc')

--- a/app/Http/Controllers/Api/SchedulesController.php
+++ b/app/Http/Controllers/Api/SchedulesController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/TeamUsersController.php
+++ b/app/Http/Controllers/Api/TeamUsersController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/TeamsController.php
+++ b/app/Http/Controllers/Api/TeamsController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/TreatmentsController.php
+++ b/app/Http/Controllers/Api/TreatmentsController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -11,21 +11,21 @@ use App\User;
     class UsersController extends Controller
     {
         // ログイン中のユーザー情報を取得
-        public function show()
+        public function getLoginUser()
         {   
             if(Auth::user()){
                 $userData = Auth::user(); 
                 return response()->json($userData);
             }
-          }
-          
-     //看護師表示
-    public function allstaffs(){ 
-     // $patients = Patient::where('ward_id','=', $wardId)
-    // ->orderBy('room', 'asc')
-    // ->get();
-    $staffs = User::orderBy('id','asc')->get();
-    return $staffs;
+        }
+
+        //看護師表示
+        public function allstaffs(){ 
+        // $patients = Patient::where('ward_id','=', $wardId)
+        // ->orderBy('room', 'asc')
+        // ->get();
+            $staffs = User::orderBy('id','asc')->get();
+            return $staffs;
         }
     }
     

--- a/app/Http/Controllers/Api/UsersPatientsController.php
+++ b/app/Http/Controllers/Api/UsersPatientsController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/app/Http/Controllers/Api/WardsController.php
+++ b/app/Http/Controllers/Api/WardsController.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace App\Http\Controllers;
-
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Auth;
 use Validate;

--- a/resources/js/components/pages/leader/PatientsList.vue
+++ b/resources/js/components/pages/leader/PatientsList.vue
@@ -2,8 +2,8 @@
     <div class="patientsLists">
         <v-list subheader>
             <v-subheader>患者一覧</v-subheader>
-            <template v-for="(patient, index) in patients">
-                <v-list-item :key="patient.id" class="px-8">
+            <div v-for="(patient, index) in patients" :key="patient.id">
+                <v-list-item class="px-8">
                     <v-list-item-avatar>
                         <v-icon class="ma-2 mdi-36px" color="#62ABF8"
                             >mdi-account</v-icon
@@ -40,21 +40,28 @@
                     v-if="index + 1 < patients.length"
                     :key="index"
                 ></v-divider>
-            </template>
+            </div>
         </v-list>
-        
-<!-- はよん追記 -->
+
+        <!-- はよん追記 -->
         <v-list>
-          <v-text-field v-model="editPatient.room"></v-text-field>
-          <v-text-field v-model="editPatient.name"></v-text-field>
-          <v-text-field v-model="editPatient.sex"></v-text-field>
-          <v-text-field v-model="editPatient.birthday"></v-text-field>
-          <v-text-field v-model="editPatient.hospitalization_date"></v-text-field>
-          <v-text-field v-model="editPatient.surgery_date"></v-text-field>
-          <v-text-field v-model="editPatient.memo"></v-text-field>
-          <v-btn class="ma-2" outlined color="pink lighten-1" @click="Update(editPatient.id)">
+            <v-text-field v-model="editPatient.room"></v-text-field>
+            <v-text-field v-model="editPatient.name"></v-text-field>
+            <v-text-field v-model="editPatient.sex"></v-text-field>
+            <v-text-field v-model="editPatient.birthday"></v-text-field>
+            <v-text-field
+                v-model="editPatient.hospitalization_date"
+            ></v-text-field>
+            <v-text-field v-model="editPatient.surgery_date"></v-text-field>
+            <v-text-field v-model="editPatient.memo"></v-text-field>
+            <v-btn
+                class="ma-2"
+                outlined
+                color="pink lighten-1"
+                @click="Update(editPatient.id)"
+            >
                 変更
-          </v-btn>
+            </v-btn>
         </v-list>
     </div>
 </template>
@@ -67,21 +74,21 @@ export default {
     components: {},
     data: () => ({
         patients: [],
-        editPatient:{
-          room: "",
-          name: "",
-          sex: "",
-          birthday: "",
-          hospitalization_date: "",
-          surgery_date: "",
-          memo: ""
-        },
+        editPatient: {
+            room: "",
+            name: "",
+            sex: "",
+            birthday: "",
+            hospitalization_date: "",
+            surgery_date: "",
+            memo: ""
+        }
     }),
     methods: {
-      // 患者一覧取得
+        // 患者一覧取得
         fetchPatients: function() {
             axios
-                .get("/api/allPatient")
+                .get("/api/patients/get/all")
                 .then(res => {
                     console.log("status:", res.status);
                     console.log("body:", res.data);
@@ -96,7 +103,7 @@ export default {
         Delete: function(patientId) {
             if (confirm("削除してよろしいでしょうか?"))
                 axios
-                    .delete("/api/delPatient", {
+                    .delete("/api/patients/delete", {
                         data: { id: patientId }
                     })
                     .then(res => {
@@ -110,52 +117,49 @@ export default {
         },
 
         // 更新する患者情報取得
-        Edit: function(patientId){
+        Edit: function(patientId) {
             axios
-                .get('/api/getPatient/'+patientId,{
+                .get("/api/patients/get/" + patientId, {})
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.editPatient = res.data;
                 })
-                .then((res)=>{
-                    console.log('status:', res.status);
-                    console.log('body:', res.data);
-                    this.editPatient = res.data
-                })
-                .catch(err =>{
-                    console.log('err:', err);
+                .catch(err => {
+                    console.log("err:", err);
                 });
         },
 
         // 患者情報更新
-        Update: function(editPatientId){
+        Update: function(editPatientId) {
             axios
-                .post('/api/updatePatient/'+editPatientId
-                ,{
-                  id:editPatientId,
-                  patient:this.editPatient,
-                  patient_room:this.editPatient.room,
-                  patient_name:this.editPatient.name,
-                  patient_sex:this.editPatient.sex,
-                  patient_birthday:this.editPatient.birthday,
-                  patient_hospitalization:this.editPatient.hospitalization_date,
-                  patient_surgery:this.editPatient.surgery_date,
-                  patient_memo:this.editPatient.memo
+                .post("/api/patients/update/" + editPatientId, {
+                    id: editPatientId,
+                    patient: this.editPatient,
+                    patient_room: this.editPatient.room,
+                    patient_name: this.editPatient.name,
+                    patient_sex: this.editPatient.sex,
+                    patient_birthday: this.editPatient.birthday,
+                    patient_hospitalization: this.editPatient
+                        .hospitalization_date,
+                    patient_surgery: this.editPatient.surgery_date,
+                    patient_memo: this.editPatient.memo
                 })
-                .then((res)=>{
-                    console.log('status:', res.status);
-                    console.log('body:', res.data);
-                    this.patient = res.data
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.patient = res.data;
                 })
-                .catch(err =>{
-                    console.log('err:', err);
+                .catch(err => {
+                    console.log("err:", err);
                 });
-        },
+        }
     },
 
-
-  created() {
-    this.fetchPatients()
-  },
-  };
-
+    created() {
+        this.fetchPatients();
+    }
+};
 </script>
 
 <style scoped>

--- a/resources/js/components/pages/leader/RegistPatient.vue
+++ b/resources/js/components/pages/leader/RegistPatient.vue
@@ -299,7 +299,7 @@ export default {
                     }
                 };
                 axios
-                    .post("api/addPatient", formData, config)
+                    .post("api/patients/post", formData, config)
                     .then(res => {
                         this.patient = res.data;
                         const selectedGenderRole = res.data.sex;

--- a/resources/js/components/pages/leader/SelectStaff.vue
+++ b/resources/js/components/pages/leader/SelectStaff.vue
@@ -1,16 +1,16 @@
-<template> 
+<template>
     <!-- 仮オブジェクト -->
     <v-card>
-      <v-list-item>
-        <v-list-item-content>
-          <v-list-item-title>【リーダー】スタッフ一覧</v-list-item-title>
-          <ul >
-            <li v-for="staff in staffs" v-bind:key="staff.id"> 
-              {{staff.name}} 
-            </li>
-          </ul>
-        </v-list-item-content>
-      </v-list-item>
+        <v-list-item>
+            <v-list-item-content>
+                <v-list-item-title>【リーダー】スタッフ一覧</v-list-item-title>
+                <ul>
+                    <li v-for="staff in staffs" v-bind:key="staff.id">
+                        {{ staff.name }}
+                    </li>
+                </ul>
+            </v-list-item-content>
+        </v-list-item>
     </v-card>
     <!-- ここまで -->
 </template>
@@ -21,24 +21,24 @@
 export default {
     components: {},
     data: () => ({
-      staffs:[],
+        staffs: []
     }),
     methods: {
-      fetchStaff: function(){
-      axios.get('/api/allStaffs')
-      .then((res)=>{
-        console.log('status:', res.status);
-        console.log('body:', res.data);
-        this.staffs = res.data 
-      })
-      .catch(err =>{
-      console.log('err:', err);
-      })
-    },
-
+        fetchStaff: function() {
+            axios
+                .get("/api/users/get/all")
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.staffs = res.data;
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
+        }
     },
     created() {
-      this.fetchStaff()
+        this.fetchStaff();
     }
 };
 </script>

--- a/resources/js/components/pages/leader/TreatmentList.vue
+++ b/resources/js/components/pages/leader/TreatmentList.vue
@@ -1,40 +1,52 @@
-<template> 
+<template>
     <!-- 仮オブジェクト -->
     <v-card>
-      <v-list-item>
-        <v-list-item-content>
-          <v-list-item-title>【リーダー】処置一覧</v-list-item-title>
-          <ul >
-            <li v-for="treatment in treatments" v-bind:key="treatment.id"> 
-              {{treatment.name}} 
-              <v-list-item-icon>
-                        <v-icon
-                            class="ma-2"
-                            outlined
-                            color="#6c6c6c"
-                            @click="Edit(treatment.id)"
-                            >mdi-pencil</v-icon
-                        >
-                        <v-icon
-                            class="ma-2"
-                            outlined
-                            color="#6c6c6c"
-                            @click="Delete(treatment.id)"
-                            >mdi-delete</v-icon
-                        >
-                    </v-list-item-icon>
-                </li>
-          </ul>
-          <v-list>
-          <v-text-field v-model="editTreatment.name"></v-text-field>
-          <v-text-field v-model="editTreatment.time_required"></v-text-field>
-          <v-text-field v-model="editTreatment.required_flg"></v-text-field>
-          <v-btn class="ma-2" outlined color="pink lighten-1" @click="Update(editTreatment.id)">
-                変更
-          </v-btn>
-        </v-list>
-        </v-list-item-content>
-      </v-list-item>
+        <v-list-item>
+            <v-list-item-content>
+                <v-list-item-title>【リーダー】処置一覧</v-list-item-title>
+                <ul>
+                    <li
+                        v-for="treatment in treatments"
+                        v-bind:key="treatment.id"
+                    >
+                        {{ treatment.name }}
+                        <v-list-item-icon>
+                            <v-icon
+                                class="ma-2"
+                                outlined
+                                color="#6c6c6c"
+                                @click="Edit(treatment.id)"
+                                >mdi-pencil</v-icon
+                            >
+                            <v-icon
+                                class="ma-2"
+                                outlined
+                                color="#6c6c6c"
+                                @click="Delete(treatment.id)"
+                                >mdi-delete</v-icon
+                            >
+                        </v-list-item-icon>
+                    </li>
+                </ul>
+                <v-list>
+                    <v-text-field v-model="editTreatment.name"></v-text-field>
+                    <v-text-field
+                        v-model="editTreatment.time_required"
+                    ></v-text-field>
+                    <v-text-field
+                        v-model="editTreatment.required_flg"
+                    ></v-text-field>
+                    <v-btn
+                        class="ma-2"
+                        outlined
+                        color="pink lighten-1"
+                        @click="Update(editTreatment.id)"
+                    >
+                        変更
+                    </v-btn>
+                </v-list>
+            </v-list-item-content>
+        </v-list-item>
     </v-card>
     <!-- ここまで -->
 </template>
@@ -43,32 +55,33 @@
 
 // Vue
 export default {
-  components: {},
-  data: () => ({
-    treatments:[],
-    editTreatment:{
-          name: "",
-          time_required: "",
-          required_flg: "",
+    components: {},
+    data: () => ({
+        treatments: [],
+        editTreatment: {
+            name: "",
+            time_required: "",
+            required_flg: ""
+        }
+    }),
+    methods: {
+        fetchTreatment: function() {
+            axios
+                .get("/api/treatments/get/all")
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.treatments = res.data;
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
         },
-  }),
-  methods: {
-    fetchTreatment: function(){
-      axios.get('/api/allTreatment')
-      .then((res)=>{
-        console.log('status:', res.status);
-        console.log('body:', res.data);
-        this.treatments = res.data 
-      })
-      .catch(err =>{
-      console.log('err:', err);
-      })
-    },
-     //処置削除
+        //処置削除
         Delete: function(treatmentId) {
             if (confirm("削除してよろしいでしょうか?"))
                 axios
-                    .delete("/api/delTreatment", {
+                    .delete("/api/treatments/delete", {
                         data: { id: treatmentId }
                     })
                     .then(res => {
@@ -81,45 +94,43 @@ export default {
                     });
         },
 
-    // 更新する処置情報取得
-        Edit: function(treatmentId){
+        // 更新する処置情報取得
+        Edit: function(treatmentId) {
             axios
-                .get('/api/getTreatment/'+treatmentId,{
+                .get("/api/treatments/get/" + treatmentId, {})
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.editTreatment = res.data;
                 })
-                .then((res)=>{
-                    console.log('status:', res.status);
-                    console.log('body:', res.data);
-                    this.editTreatment = res.data
-                })
-                .catch(err =>{
-                    console.log('err:', err);
+                .catch(err => {
+                    console.log("err:", err);
                 });
         },
-      // 患者情報更新
-        Update: function(editTreatmentId){
+        // 患者情報更新
+        Update: function(editTreatmentId) {
             axios
-                .post('/api/updateTreatment/'+editTreatmentId
-                ,{
-                  id:editTreatmentId,
-                  treatment:this.editTreatment,
-                  treatment_name:this.editTreatment.name,
-                  treatment_time:this.editTreatment.time_required,
-                  treatment_required:this.editTreatment.required_flg,
+                .post("/api/treatments/update/" + editTreatmentId, {
+                    id: editTreatmentId,
+                    treatment: this.editTreatment,
+                    treatment_name: this.editTreatment.name,
+                    treatment_time: this.editTreatment.time_required,
+                    treatment_required: this.editTreatment.required_flg
                 })
-                .then((res)=>{
-                    console.log('status:', res.status);
-                    console.log('body:', res.data);
-                    this.treatment = res.data
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.treatment = res.data;
                 })
-                .catch(err =>{
-                    console.log('err:', err);
+                .catch(err => {
+                    console.log("err:", err);
                 });
-        },
+        }
     },
-  created() {
-    this.fetchTreatment()
-  },
-  };
+    created() {
+        this.fetchTreatment();
+    }
+};
 </script>
 
 <style scoped>

--- a/resources/js/components/pages/staff/SelectPatients.vue
+++ b/resources/js/components/pages/staff/SelectPatients.vue
@@ -1,27 +1,32 @@
-<template> 
+<template>
     <!-- 仮オブジェクト -->
     <v-card>
-      <v-list-item>
-        <v-list-item-content>
-          <v-list-item-title>【スタッフ】患者選択</v-list-item-title>
-          <ul >
-            <li v-for="patient in patients" v-bind:key="patient.id"> 
-              {{patient.room}} 
-              {{ patient.name }} 
-              <!-- dbには番号で登録してるけど表示は日本語で -->
-              {{patient.sex}}
-              <!-- dbには誕生日登録してるけど表示は年齢にしたい！ -->
-              {{patient.birthday}}
-              {{patient.hospitalization_date}}
-              {{patient.surgery_date}}
-              {{patient.memo}}
-            </li>
-          </ul>
-          <v-btn class="ma-2" outlined color="pink lighten-1" @click="select(patients.id)">
-                決定
-          </v-btn>
-        </v-list-item-content>
-      </v-list-item>
+        <v-list-item>
+            <v-list-item-content>
+                <v-list-item-title>【スタッフ】患者選択</v-list-item-title>
+                <ul>
+                    <li v-for="patient in patients" v-bind:key="patient.id">
+                        {{ patient.room }}
+                        {{ patient.name }}
+                        <!-- dbには番号で登録してるけど表示は日本語で -->
+                        {{ patient.sex }}
+                        <!-- dbには誕生日登録してるけど表示は年齢にしたい！ -->
+                        {{ patient.birthday }}
+                        {{ patient.hospitalization_date }}
+                        {{ patient.surgery_date }}
+                        {{ patient.memo }}
+                    </li>
+                </ul>
+                <v-btn
+                    class="ma-2"
+                    outlined
+                    color="pink lighten-1"
+                    @click="select(patients.id)"
+                >
+                    決定
+                </v-btn>
+            </v-list-item-content>
+        </v-list-item>
     </v-card>
     <!-- ここまで -->
 </template>
@@ -30,45 +35,45 @@
 
 // Vue
 export default {
-  components: {},
-  data: () => ({
-    patients:[],
-    usersPatients:[],
-  }),
-  methods: {
-    fetchPatients: function(){
-      axios.get('/api/allPatient')
-      .then((res)=>{
-        console.log('status:', res.status);
-        console.log('body:', res.data);
-        this.patients = res.data 
-      })
-      .catch(err =>{
-      console.log('err:', err);
-      })
+    components: {},
+    data: () => ({
+        patients: [],
+        usersPatients: []
+    }),
+    methods: {
+        fetchPatients: function() {
+            axios
+                .get("/api/patients/get/all")
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.patients = res.data;
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
+        },
+
+        select: function(patientsId) {
+            console.log(patientsId);
+            axios
+                .post("/api/add/" + patientsId, {
+                    id: patientsId
+                })
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.usersPatients = res.data;
+                })
+                .catch(err => {
+                    "err:", err;
+                });
+        }
     },
-
-    select:function(patientsId){
-      console.log(patientsId)
-      axios.post("/api/add/"+patientsId
-      ,{
-        id:patientsId
-      })
-      .then(res => {
-        console.log('status:', res.status);
-        console.log('body:', res.data);
-        this.usersPatients = res.data 
-      })
-      .catch(err => {'err:', err})
-            } 
-    },
-  created() {
-    this.fetchPatients()
-  },
-  };
-
-
-  
+    created() {
+        this.fetchPatients();
+    }
+};
 </script>
 
 <style scoped>

--- a/resources/js/store/modules/auth.js
+++ b/resources/js/store/modules/auth.js
@@ -13,7 +13,7 @@ const mutations = {
 const actions = {
     async getLoginUserData({ commit }) {
         await axios
-            .get("/api/user/fetch")
+            .get("/api/users/login-user")
             .then(res => {
                 commit("setLoginUser", res.data);
             })

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
-use App\User;
+
 
 Route::middleware('auth:api')->get('/user', function (Request $request) {
   return $request->user();
@@ -11,62 +11,50 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::group(['middleware' => 'auth'], function () {
   // -----users_tabel crud -----
   // ログイン中のユーザー情報取得
-  Route::get('user/fetch', 'Api\UsersController@show');
+  Route::get('/users/login-user', 'Api\UsersController@getLoginUser');
+  // 病棟内の全ユーザー取得
+  Route::get('/users/get/all','Api\UsersController@allstaffs');
+
+
+  // -----はよん追記-----
+  // -----patients_tabel API -----
+  // 患者一覧表示
+  Route::get('/patients/get/all','Api\PatientsController@getAllPatients');
+
+  // 患者登録
+  Route::post('/patients/post','Api\PatientsController@addPatients'); 
+
+  // 患者削除
+  Route::delete('/patients/delete/', 'Api\PatientsController@destroy');
+
+  // 更新する患者取得 
+  Route::get('/patients/get/{patient_id}','Api\PatientsController@editPatient');
+
+  // 患者更新
+  Route::post('/patients/update/{patient_id}','Api\PatientsController@updatePatient');
+
+  // -----usersPatients_tabel API -----
+  // 佐藤<ここは命名いじってません
+  // 担当患者登録
+  Route::post('/add/{userPatients}','Api\UsersPatientsController@add'); 
+
+  // 担当患者取得
+  Route::get('/get','Api\UsersPatientsController@get'); 
+
+  // -----treatment_tabel API -----
+  // 処置一覧表示
+  Route::get('/treatments/get/all','Api\TreatmentsController@alltreatments');
+
+  // 処置登録
+  Route::post('/treatments/post','Api\TreatmentsController@addTreatment'); 
+
+  // 処置削除
+  Route::delete('/treatments/delete', 'Api\TreatmentsController@destroy');
+
+  // 更新する処置取得
+  Route::get('/treatments/get/{treatment}','Api\TreatmentsController@editTreatment');
+
+  // 処置更新
+  Route::post('/treatments/update/{editTreatment}','Api\TreatmentsController@updateTreatment');
 
 });
-
-
-// -----はよん追記-----
-// -----patients_tabel API -----
-// 患者一覧表示
-Route::get('/allPatient','PatientsController@Allpatients');
-
-// 患者登録
-Route::post('/addPatient','PatientsController@add'); 
-
-// 患者削除
-Route::delete('/delPatient', 'PatientsController@destroy');
-
-// 更新する患者取得
-Route::get('/getPatient/{patient}','PatientsController@editPatient');
-
-// 患者更新
-Route::post('/updatePatient/{editPatient}','PatientsController@updatePatient');
-
-// -----usersPatients_tabel API -----
-// 担当患者登録
-Route::post('/add/{userPatients}','UsersPatientsController@add'); 
-
-// 担当患者取得
-Route::get('/get','UsersPatientsController@get'); 
-
-// -----treatment_tabel API -----
-// 処置一覧表示
-Route::get('/allTreatment','TreatmentsController@alltreatments');
-
-// 処置登録
-Route::post('/addTreatment','TreatmentsController@addTreatment'); 
-
-// 患者削除
-Route::delete('/delTreatment', 'TreatmentsController@destroy');
-
-// 更新する患者取得
-Route::get('/getTreatment/{treatment}','TreatmentsController@editTreatment');
-
-// 患者更新
-Route::post('/updateTreatment/{editTreatment}','TreatmentsController@updateTreatment');
-
-// -----user_tabel API -----
-// 看護師一覧表示
-// Route::get('/allStaffs','UsersController@allstaffs');
-Route::get('/allStaffs',function()
-{
-    // $wardId= Auth::ward_id();
-     // $patients = Patient::where('ward_id','=', $wardId)
-    // ->orderBy('room', 'asc')
-    // ->get();
-    $staffs = User::orderBy('id','asc')->get();
-    return $staffs;
-}
-
-);


### PR DESCRIPTION
# API名変更
- [対象(複数形)]/[処理内容]/[詳細(idなど)]　の規則で命名
- Vue側も変更してます
- users_patientsのAPIは作成中とのことだったので変更していませんが、命名合わせていただけると助かります！

# namespace変更（判別しやすくしたかったので）
- 全てのcontrollerのnamespaceに\Apiを追記
- それに合わせて、api.phpのRouteの第二引数に\Apiを追記

# PatientsList.vueのエラー修正
- templeteタグの中にtempleteを入れ子にはしない方が良いっぽいです
- 今回は内部のtempleteにv-forを書いてたんですが、templeteタグの中のv-forってkeyを指定できないらしいです