### PR TITLE
役割選択リンク飛ばないエラー修正

### DIFF
--- a/resources/js/components/pages/staff/SelectRole.vue
+++ b/resources/js/components/pages/staff/SelectRole.vue
@@ -3,7 +3,14 @@
         <div>
             <v-app-bar
             flat color="white" fixed light>
-                <span @click="logout" style="cursor: pointer;">＜ 戻る</span>
+            <!--ここにログアウト付けたかった -->
+                <router-link
+                    :to="{ name: 'SelectStaff' }"
+                    style="text-decoration: none;"
+                >
+                ＜ 戻る
+                </router-link>
+
             </v-app-bar>
 
             <div class="message">


### PR DESCRIPTION
・ログアウト実装しようとしていた残骸がエラーを引き起こして他のrouter-linkもリンクが飛ばなくなっていたので、修正しました