### PR TITLE
[追加]スタッフスケジュール一覧 / スケジュールの表示と詳細モーダル

### DIFF
--- a/resources/js/components/items/MomentJs.vue
+++ b/resources/js/components/items/MomentJs.vue
@@ -1,5 +1,5 @@
 <template>
-    <p class="moment ma-0">{{ setTime }}歳</p>
+    <p class="moment ma-0">{{ setTime }}</p>
 </template>
 <script>
 import moment from "moment";
@@ -9,7 +9,7 @@ export default {
         time: String
     },
     computed: {
-        postTime: function() {
+        setTime: function() {
             return moment(this.time)
                 .add(9, "hours")
                 .format("YYYY/MM/DD(ddd) hh:mm");

--- a/resources/js/components/pages/staff/RegistTreatmentSchedule.vue
+++ b/resources/js/components/pages/staff/RegistTreatmentSchedule.vue
@@ -1,108 +1,120 @@
 <template>
-  <v-container>
-    <v-stepper value="2" alt-labels>
-      <v-stepper-header>
-        <v-stepper-step step="1" complete>患者選択</v-stepper-step>
+    <v-container>
+        <v-stepper value="2" alt-labels>
+            <v-stepper-header>
+                <v-stepper-step step="1" complete>患者選択</v-stepper-step>
 
-        <v-divider></v-divider>
+                <v-divider></v-divider>
 
-        <v-stepper-step step="2">処置設定</v-stepper-step>
+                <v-stepper-step step="2">処置設定</v-stepper-step>
 
-        <v-divider></v-divider>
+                <v-divider></v-divider>
 
-        <v-stepper-step step="3">スケジュール設定</v-stepper-step>
-      </v-stepper-header>
-    </v-stepper>
-    <div class="patient_wrap">
-      <li v-if="usersPatients[setTreatmentPage]">
-        {{usersPatients[setTreatmentPage].room }}号室
-        {{usersPatients[setTreatmentPage].name }}さん
-        <span
-          v-if="usersPatients[setTreatmentPage].sex　== 1"
-        >男性</span>
-        <span v-else-if="usersPatients[setTreatmentPage].sex　== 2">女性</span>
-        <BirthdayMomentJS :time="usersPatients[setTreatmentPage].birthday" />
-      </li>
-      {{setTreatmentPage + 1}}/{{usersPatientsLength + 1}}人
-    </div>
-    <p class="center">今日行う処置を選択してください</p>
+                <v-stepper-step step="3">スケジュール設定</v-stepper-step>
+            </v-stepper-header>
+        </v-stepper>
+        <div class="patient_wrap">
+            <li v-if="usersPatients[setTreatmentPage]">
+                {{ usersPatients[setTreatmentPage].room }}号室
+                {{ usersPatients[setTreatmentPage].name }}さん
+                <span v-if="usersPatients[setTreatmentPage].sex == 1"
+                    >男性</span
+                >
+                <span v-else-if="usersPatients[setTreatmentPage].sex == 2"
+                    >女性</span
+                >
+                <BirthdayMomentJS
+                    :time="usersPatients[setTreatmentPage].birthday"
+                />
+            </li>
+            {{ setTreatmentPage + 1 }}/{{ usersPatientsLength + 1 }}人
+        </div>
+        <p class="center">今日行う処置を選択してください</p>
 
-    <div class="select_wrap">
-      <div class="cp_ipselect cp_sl02">
-        <select v-model="selectedTreatment">
-          <option disabled value>選択してください</option>
-          <option
-            v-for="treatment in treatments"
-            :value="treatment.id"
-            :key="treatment.id"
-          >{{treatment.name}}</option>
-        </select>
-      </div>
-      <div class="button_wrap my-5">
+        <div class="select_wrap">
+            <div class="cp_ipselect cp_sl02">
+                <select v-model="selectedTreatment">
+                    <option disabled value>選択してください</option>
+                    <option
+                        v-for="treatment in treatments"
+                        :value="treatment.id"
+                        :key="treatment.id"
+                        >{{ treatment.name }}</option
+                    >
+                </select>
+            </div>
+            <div class="button_wrap my-5">
+                <v-btn
+                    rounded
+                    depressed
+                    dark
+                    width="50"
+                    class="button"
+                    color="#2196F3"
+                    @click="pushSettreatmentData()"
+                    >追加</v-btn
+                >
+            </div>
+        </div>
+
+        <div>
+            <p>登録済みの処置（{{ setTreatmentsData.length }}）</p>
+        </div>
+        <table>
+            <!-- テーブルヘッダー -->
+            <thead>
+                <tr>
+                    <th class="comment"></th>
+                    <th class="time_input"></th>
+                    <th class="button"></th>
+                </tr>
+            </thead>
+            <tbody v-if="setTreatmentsData.length > 0">
+                <tr
+                    v-for="(setTreatment, index) in setTreatmentsData"
+                    :key="index"
+                >
+                    <td class="treatment_name center">
+                        {{ setTreatment.treatment_name }}
+                    </td>
+                    <td class="time_input">
+                        <vue-timepicker
+                            :minute-interval="10"
+                            v-model="treatmentTimes[index]"
+                            id="start_time"
+                            name="startTime"
+                            placeholder="開始時間"
+                            hour-label="時"
+                            minute-label="分"
+                            input-class="form-control"
+                            @input="updateSetTreatmentsData(index)"
+                        ></vue-timepicker>
+                    </td>
+                    <td class="button">
+                        <v-btn
+                            color="blue lighten-1"
+                            depressed
+                            fab
+                            small
+                            icon
+                            @click="deleteTreatmentData(index)"
+                        >
+                            <v-icon>mdi-trash-can</v-icon>
+                        </v-btn>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
         <v-btn
-          rounded
-          depressed
-          dark
-          width="50"
-          class="button"
-          color="#2196F3"
-          @click="pushSettreatmentData()"
-        >追加</v-btn>
-      </div>
-    </div>
-
-    <div>
-      <p>登録済みの処置（{{setTreatmentsData.length}}）</p>
-    </div>
-    <table>
-      <!-- テーブルヘッダー -->
-      <thead>
-        <tr>
-          <th class="comment"></th>
-          <th class="time_input"></th>
-          <th class="button"></th>
-        </tr>
-      </thead>
-      <tbody v-if="setTreatmentsData.length > 0">
-        <tr v-for="(setTreatment,index) in setTreatmentsData" :key="index">
-          <td class="treatment_name center">{{setTreatment.treatment_name}}</td>
-          <td class="time_input">
-            <vue-timepicker
-              :minute-interval="10"
-              v-model="treatmentTimes[index]"
-              id="start_time"
-              name="startTime"
-              placeholder="開始時間"
-              hour-label="時"
-              minute-label="分"
-              input-class="form-control"
-              @input="updateSetTreatmentsData(index)"
-            ></vue-timepicker>
-          </td>
-          <td class="button">
-            <v-btn
-              color="blue lighten-1"
-              depressed
-              fab
-              small
-              icon
-              @click="deleteTreatmentData(index)"
-            >
-              <v-icon>mdi-trash-can</v-icon>
-            </v-btn>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <v-btn
-      class="mx-auto my-4 px-12 py-4 submit_btn"
-      rounded
-      dark
-      color="#62ABF8"
-      type="submit"
-      @click="setTreatmentsSchedule()"
-    >保存</v-btn>
-  </v-container>
+            class="mx-auto my-4 px-12 py-4 submit_btn"
+            rounded
+            dark
+            color="#62ABF8"
+            type="submit"
+            @click="setTreatmentsSchedule()"
+            >保存</v-btn
+        >
+    </v-container>
 </template>
 <script>
 // コンポーネントのインポート
@@ -111,249 +123,250 @@ import "vue2-timepicker/dist/VueTimepicker.css";
 import BirthdayMomentJS from "../../items/BirthdayMomentJs";
 // Vue
 export default {
-  components: {
-    "vue-timepicker": VueTimepicker,
-    BirthdayMomentJS
-  },
-  data: () => ({
-    /**
-     *
-     * @param {Array} usersPatients・・・・・・・ログインユーザーの担当患者データ
-     * @param {Int} usersPatientsLength・・・・・・・ログインユーザーの担当患者数
-     * @param {Array} treatments・・・ログインユーザーが所属する病棟に登録済みの処置データ
-     * @param {Array} setTreatmentsData・・・Dialogの表示非表示を管理。
-     * @param {Object} setTreatmentPage・・・患者のプロフィールデータを管理
-     * @param {Array} selectedTreatment・・・追加した処置のデータ
-     * @param {Array} schedule・・・DB側へ送るスケジュールデータ
-     *
-     **/
-    usersPatients: [],
-    usersPatientsLength: 0,
-    treatments: [],
-    setTreatmentsData: [],
-    setTreatmentPage: 0,
-    selectedTreatment: [],
-    treatmentTimes: [],
-    schedule: {
-      treatment_id: "",
-      patient_id: "",
-      start_date: ""
+    components: {
+        "vue-timepicker": VueTimepicker,
+        BirthdayMomentJS
     },
-    today: ""
-  }),
-  computed: {
-    // DB保存用に日付を整形
-    setToday: function() {
-      var today = new Date();
-      var year = today.getFullYear();
-      var month = today.getMonth() + 1;
-      var week = today.getDay();
-      var day = today.getDate();
-      if (month < 10) {
-        month = "0" + month;
-      }
-      if (day < 10) {
-        day = "0" + day;
-      }
-      return (this.today = year + "-" + month + "-" + day);
+    data: () => ({
+        /**
+         *
+         * @param {Array} usersPatients・・・・・・・ログインユーザーの担当患者データ
+         * @param {Int} usersPatientsLength・・・・・・・ログインユーザーの担当患者数
+         * @param {Array} treatments・・・ログインユーザーが所属する病棟に登録済みの処置データ
+         * @param {Array} setTreatmentsData・・・DB側へ送るスケジュールデータ
+         * @param {Object} setTreatmentPage・・・担当患者のうち何人目のデータのなのかを管理（index）
+         * @param {Array} selectedTreatment・・・追加した処置スケジュールのデータ
+         * @param {Array} schedule・・・DB側へ送るスケジュールデータ形式？　使ってないです・・・
+         * @param {String} today・・・今日の日付
+         *
+         **/
+        usersPatients: [],
+        usersPatientsLength: 0,
+        treatments: [],
+        setTreatmentsData: [],
+        setTreatmentPage: 0,
+        selectedTreatment: [],
+        treatmentTimes: [],
+        schedule: {
+            treatment_id: "",
+            patient_id: "",
+            start_date: ""
+        },
+        today: ""
+    }),
+    computed: {
+        // DB保存用に日付を整形
+        setToday: function() {
+            var today = new Date();
+            var year = today.getFullYear();
+            var month = today.getMonth() + 1;
+            var week = today.getDay();
+            var day = today.getDate();
+            if (month < 10) {
+                month = "0" + month;
+            }
+            if (day < 10) {
+                day = "0" + day;
+            }
+            return (this.today = year + "-" + month + "-" + day);
+        }
+    },
+    methods: {
+        fetchPatients: function() {
+            axios
+                .get("/api/users_patients/get/all")
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.usersPatients = res.data;
+                    this.usersPatientsLength = res.data.length;
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
+        },
+        fetchTreatment: function() {
+            axios
+                .get("/api/treatments/get/all")
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.treatments = res.data;
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
+        },
+        // 処置を追加して入力欄を表示
+        pushSettreatmentData: function() {
+            const selectedTreatmentId = this.selectedTreatment;
+            const selectedTreatmentName = this.treatments.filter(function(
+                item,
+                index
+            ) {
+                if (item.id == selectedTreatmentId) return true;
+            });
+            this.setTreatmentsData.push({
+                treatment_id: selectedTreatmentId,
+                treatment_name: selectedTreatmentName[0].name,
+                patient_id: this.usersPatients[this.setTreatmentPage].id,
+                start_date: ""
+            });
+        },
+        // 登録したスケジュールの削除
+        deleteTreatmentData: function(index) {
+            this.setTreatmentsData.splice(index, 1);
+        },
+        // 登録したスケジュールの開始時間を更新
+        updateSetTreatmentsData: function(index) {
+            const setTime = this.treatmentTimes[index];
+            if (setTime.HH && setTime.mm) {
+                const startTime =
+                    this.setToday + " " + setTime.HH + ":" + setTime.mm + ":00";
+                this.setTreatmentsData[index].start_date = startTime;
+            } else {
+                const startTime = this.setToday;
+                this.setTreatmentsData[index].start_date = startTime;
+            }
+        },
+        // 登録した処置をDBに保存
+        setTreatmentsSchedule: function() {
+            console.log(this.setTreatmentsData);
+            axios
+                .post("/api/schedules/post", {
+                    tratmentSchedule: this.setTreatmentsData
+                })
+                .then(res => {
+                    console.log("status:", res.status);
+                    console.log("body:", res.data);
+                    this.setTreatmentPage++;
+                    this.setTreatmentsData = [];
+                    //　全員分登録が完了したら...
+                    if (this.setTreatmentPage == this.usersPatientsLength) {
+                        const transitionDestinationObj = {
+                            name: "RegistSchedule"
+                        };
+                        this.$router.push(transitionDestinationObj);
+                    }
+                })
+                .catch(err => {
+                    console.log("err:", err);
+                });
+        }
+    },
+    created() {
+        this.fetchPatients();
+        this.fetchTreatment();
     }
-  },
-  methods: {
-    fetchPatients: function() {
-      axios
-        .get("/api/users_patients/get/all")
-        .then(res => {
-          console.log("status:", res.status);
-          console.log("body:", res.data);
-          this.usersPatients = res.data;
-          this.usersPatientsLength = res.data.length;
-        })
-        .catch(err => {
-          console.log("err:", err);
-        });
-    },
-    fetchTreatment: function() {
-      axios
-        .get("/api/treatments/get/all")
-        .then(res => {
-          console.log("status:", res.status);
-          console.log("body:", res.data);
-          this.treatments = res.data;
-        })
-        .catch(err => {
-          console.log("err:", err);
-        });
-    },
-    // 処置を追加して入力欄を表示
-    pushSettreatmentData: function() {
-      const selectedTreatmentId = this.selectedTreatment;
-      const selectedTreatmentName = this.treatments.filter(function(
-        item,
-        index
-      ) {
-        if (item.id == selectedTreatmentId) return true;
-      });
-      this.setTreatmentsData.push({
-        treatment_id: selectedTreatmentId,
-        treatment_name: selectedTreatmentName[0].name,
-        patient_id: this.usersPatients[this.setTreatmentPage].id,
-        start_date: ""
-      });
-    },
-    // 登録したスケジュールの削除
-    deleteTreatmentData: function(index) {
-      this.setTreatmentsData.splice(index, 1);
-    },
-    // 登録したスケジュールの開始時間を更新
-    updateSetTreatmentsData: function(index) {
-      const setTime = this.treatmentTimes[index];
-      if (setTime.HH && setTime.mm) {
-        const startTime =
-          this.setToday + " " + setTime.HH + ":" + setTime.mm + ":00";
-        this.setTreatmentsData[index].start_date = startTime;
-      } else {
-        const startTime = this.setToday;
-        this.setTreatmentsData[index].start_date = startTime;
-      }
-    },
-    // 登録した処置をDBに保存
-    setTreatmentsSchedule: function() {
-      console.log(this.setTreatmentsData);
-      axios
-        .post("/api/schedules/post", {
-          tratmentSchedule: this.setTreatmentsData
-        })
-        .then(res => {
-          console.log("status:", res.status);
-          console.log("body:", res.data);
-          this.setTreatmentPage++;
-          this.setTreatmentsData = [];
-          //　全員分登録が完了したら...
-          if (this.setTreatmentPage == this.usersPatientsLength) {
-            const transitionDestinationObj = {
-              name: "RegistSchedule"
-            };
-            this.$router.push(transitionDestinationObj);
-          }
-        })
-        .catch(err => {
-          console.log("err:", err);
-        });
-    }
-  },
-  created() {
-    this.fetchPatients();
-    this.fetchTreatment();
-  }
 };
 </script>
 
 <style scoped>
 /* スコープ付きのスタイル */
 .patient_wrap {
-  margin: 1em;
+    margin: 1em;
 }
 .patient_wrap li {
-  color: #fd9549;
-  font-weight: bold;
-  list-style: none;
-  text-align: center;
+    color: #fd9549;
+    font-weight: bold;
+    list-style: none;
+    text-align: center;
 }
 
 .select_wrap,
 .time_input {
-  display: flex;
+    display: flex;
 }
 .center {
-  text-align: center;
-  margin: 0;
+    text-align: center;
+    margin: 0;
 }
 .comment {
-  width: 80px;
+    width: 80px;
 }
 .time_input,
 .comment {
-  width: 100%;
+    width: 100%;
 }
 .treatment_name {
-  background-color: #e6f4ff;
-  color: #62abf8;
+    background-color: #e6f4ff;
+    color: #62abf8;
 }
 
 .cp_ipselect {
-  overflow: hidden;
-  width: 70%;
-  margin: 1em;
+    overflow: hidden;
+    width: 70%;
+    margin: 1em;
 }
 .cp_ipselect select {
-  width: 100%;
-  padding-right: 1em;
-  cursor: pointer;
-  text-indent: 0.01px;
-  text-overflow: ellipsis;
-  border: none;
-  outline: none;
-  background: transparent;
-  background-image: none;
-  box-shadow: none;
-  -webkit-appearance: none;
-  appearance: none;
+    width: 100%;
+    padding-right: 1em;
+    cursor: pointer;
+    text-indent: 0.01px;
+    text-overflow: ellipsis;
+    border: none;
+    outline: none;
+    background: transparent;
+    background-image: none;
+    box-shadow: none;
+    -webkit-appearance: none;
+    appearance: none;
 }
 .cp_ipselect select::-ms-expand {
-  display: none;
+    display: none;
 }
 .cp_ipselect.cp_sl02 {
-  position: relative;
-  border: 1px solid #bbbbbb;
-  border-radius: 2px;
-  background: #ffffff;
+    position: relative;
+    border: 1px solid #bbbbbb;
+    border-radius: 2px;
+    background: #ffffff;
 }
 .cp_ipselect.cp_sl02::before {
-  position: absolute;
-  top: 0.8em;
-  right: 0.9em;
-  width: 0;
-  height: 0;
-  padding: 0;
-  content: "";
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 6px solid #666666;
-  pointer-events: none;
+    position: absolute;
+    top: 0.8em;
+    right: 0.9em;
+    width: 0;
+    height: 0;
+    padding: 0;
+    content: "";
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 6px solid #666666;
+    pointer-events: none;
 }
 .cp_ipselect.cp_sl02:after {
-  position: absolute;
-  top: 0;
-  right: 2.5em;
-  bottom: 0;
-  width: 1px;
-  content: "";
-  border-left: 1px solid #bbbbbb;
+    position: absolute;
+    top: 0;
+    right: 2.5em;
+    bottom: 0;
+    width: 1px;
+    content: "";
+    border-left: 1px solid #bbbbbb;
 }
 .cp_ipselect.cp_sl02 select {
-  padding: 8px 38px 8px 8px;
-  color: #666666;
+    padding: 8px 38px 8px 8px;
+    color: #666666;
 }
 .button {
-  width: 10px;
+    width: 10px;
 }
 
 .v-stepper {
-  box-shadow: none;
+    box-shadow: none;
 }
 .v-stepper__header {
-  box-shadow: none;
+    box-shadow: none;
 }
 .v-stepper--alt-labels .v-stepper__header .v-divider {
-  margin: 22px -80px 0;
+    margin: 22px -80px 0;
 }
 .v-divider {
-  max-width: 90px;
+    max-width: 90px;
 }
 .v-stepper__step {
-  padding: 10px;
+    padding: 10px;
 }
 .v-stepper--alt-labels .v-stepper__step {
-  flex-basis: 100px;
+    flex-basis: 100px;
 }
 </style>

--- a/resources/js/components/pages/staff/StaffSchedule.vue
+++ b/resources/js/components/pages/staff/StaffSchedule.vue
@@ -1,54 +1,225 @@
-<template> 
-    <!-- 仮オブジェクト -->
-    <v-card>
-        <v-list-item>
-            <v-list-item-content>
-                <v-list-item-title>【スタッフ】処置スケジュール一覧</v-list-item-title>
-                <ul>
-                    <li v-for="schedule in schedules" v-bind:key="schedule.id">
-                        {{ schedule.id }}
-                        {{ schedule.patient.room }}
-                        {{ schedule.patient.name}}
-                        {{ schedule.treatment.name}}
-                        {{ schedule.treatment.required_flg}}
-                        {{ schedule.treatment.time_required}}
-                        
-                    </li>
-                </ul>
-            </v-list-item-content>
-        </v-list-item>
-    </v-card>
+<template>
+    <div>
+        <v-row>
+            <v-col>
+                <v-sheet height="700">
+                    <v-calendar
+                        ref="calendar"
+                        v-model="focus"
+                        color="primary"
+                        :events="events"
+                        :event-color="getEventColor"
+                        :event-ripple="false"
+                        type="day"
+                        @click:event="showEvent"
+                    >
+                        <!-- nowライン設定 -->
+                        <template #day-body="{ date, week }">
+                            <div
+                                class="v-current-time"
+                                :class="{ first: date === week[0].date }"
+                                :style="{ top: nowY }"
+                            ></div>
+                        </template>
+                        <!-- nowライン設定ここまで -->
+                    </v-calendar>
+                </v-sheet>
+            </v-col>
+        </v-row>
+        <!-- クリック時に開く詳細画面 -->
+        <v-card
+            v-if="selectedOpen"
+            min-width="350px"
+            flat
+            class="detail-schedule"
+        >
+            <v-card-text>
+                <p>{{ selectedEvent.room }}</p>
+                <p>{{ selectedEvent.patient }}</p>
+                <p>{{ selectedEvent.treatment }}</p>
+                <MomentJs :time="selectedEvent.start" />
+            </v-card-text>
+            <v-card-actions>
+                <v-btn text color="secondary" @click="selectedOpen = false">
+                    閉じる
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+        <!-- クリック時に開く詳細画面 ここまで-->
+    </div>
     <!-- ここまで -->
 </template>
 <script>
-// コンポーネントのインポート
-
+import MomentJs from "../../items/MomentJs";
 // Vue
 export default {
-    components: {},
+    components: {
+        MomentJs
+    },
     data: () => ({
-      schedules:[],
+        schedules: [],
+        // ▼カレンダー関連
+        //   nowライン
+        value: "",
+        ready: false,
+        // スケジュールを格納
+        events: [],
+        focus: "",
+        colors: [
+            "blue",
+            "indigo",
+            "deep-purple",
+            "cyan",
+            "green",
+            "orange",
+            "grey darken-1"
+        ],
+        // スケジュール詳細
+        selectedEvent: {},
+        selectedElement: null,
+        selectedOpen: false
     }),
+    computed: {
+        cal() {
+            return this.ready ? this.$refs.calendar : null;
+        },
+        nowY() {
+            return this.cal
+                ? this.cal.timeToY(this.cal.times.now) + "px"
+                : "-10px";
+        }
+    },
+    mounted() {
+        //   nowライン
+        this.ready = true;
+        this.scrollToTime();
+        this.updateTime();
+    },
     methods: {
-      fetchSchedule: function() {
+        fetchSchedule: function() {
             axios
                 .get("/api/schedules/get/all")
                 .then(res => {
                     console.log("status:", res.status);
                     console.log("body:", res.data);
                     this.schedules = res.data;
+                    this.fetchEvents();
                 })
                 .catch(err => {
                     console.log("err:", err);
                 });
         },
+        // ------------ ▼nowライン ---------- //
+        getCurrentTime() {
+            return this.cal
+                ? this.cal.times.now.hour * 60 + this.cal.times.now.minute
+                : 0;
+        },
+        scrollToTime() {
+            const time = this.getCurrentTime();
+            const first = Math.max(0, time - (time % 30) - 30);
+
+            this.cal.scrollToTime(first);
+        },
+        updateTime() {
+            setInterval(() => this.cal.updateTimes(), 60 * 1000);
+        }, // イベント登録
+        // ------------ nowラインここまで ---------- //
+        // ------------ イベントの生成 ---------- //
+        fetchEvents() {
+            const getEventsData = [];
+            const eventCount = this.schedules.length;
+            for (let i = 0; i < eventCount; i++) {
+                // 開始時間と終了時刻の定義
+                const startdate = new Date(this.schedules[i].start_date);
+                const requiredTime = this.schedules[i].treatment.time_required;
+                const addition_time = requiredTime * 60 * 1000;
+                const endTime = startdate.getTime() + addition_time;
+                // イベントにpush
+                getEventsData.push({
+                    name:
+                        this.schedules[i].patient.name +
+                        " / " +
+                        this.schedules[i].treatment.name, // 処置の名前
+                    start: this.schedules[i].start_date, // 開始時刻
+                    end: endTime, // 終了時刻
+                    color: this.colors[i],
+                    timed: true,
+                    id: this.schedules[i].id,
+                    room: this.schedules[i].patient.room,
+                    treatment: this.schedules[i].treatment.name,
+                    patient: this.schedules[i].patient.name
+                });
+            }
+            this.events = getEventsData;
+        },
+        getEventColor(event) {
+            return event.color;
+        },
+        // ------------ イベントの生成ここまで ---------- //
+        // ------------ クリックしたときの詳細画面 ---------- //
+        showEvent({ nativeEvent, event }) {
+            const open = () => {
+                this.selectedEvent = event;
+                this.selectedElement = nativeEvent.target;
+                console.log(event);
+
+                setTimeout(() => (this.selectedOpen = true), 10);
+            };
+
+            if (this.selectedOpen) {
+                this.selectedOpen = false;
+                setTimeout(open, 10);
+            } else {
+                open();
+            }
+
+            nativeEvent.stopPropagation();
+        }
+        // ------------ クリックしたときの詳細画面　ここまで ---------- //
     },
     created() {
-      this.fetchSchedule();
-    },
+        this.fetchSchedule();
+    }
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+body {
+    box-sizing: border-box;
+}
 /* スコープ付きのスタイル */
+/* nowラインのスタイル */
+.v-current-time {
+    height: 2px;
+    background-color: #ea4335;
+    position: absolute;
+    left: -1px;
+    right: 0;
+    pointer-events: none;
+
+    &.first::before {
+        content: "";
+        position: absolute;
+        background-color: #ea4335;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        margin-top: -5px;
+        margin-left: -6.5px;
+    }
+}
+/* nowラインのスタイル　ここまで */
+/* スケジュール詳細のスタイル */
+.detail-schedule {
+    position: fixed;
+    bottom: 56px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 250px;
+    z-index: 5;
+    background: #fff;
+}
+/* スケジュール詳細のスタイル　ここまで */
 </style>


### PR DESCRIPTION
中途半端ですが、

- DBから取得したスケジュールデータを表示
- タスクをクリックするとタスク詳細モーダル が表示される

を実装しました。

`v-calendar`に関して大したことではないですが発見したことは下記です！

- タスクを表示する際に定義する` events`には必須の` name and end timestamp`以外にも独自の値を持たせることができるのでそこにスケジュールのidなどを持たせることができる　[StaffSchedule.vue：line140あたり]

- タスクをクリックした際に` events`で持たせた値を取得できる　[StaffSchedule.vue：line160あたり]