### PR TITLE
スタッフのスケジュール一覧表示

### DIFF
--- a/app/Http/Controllers/Api/SchedulesController.php
+++ b/app/Http/Controllers/Api/SchedulesController.php
@@ -68,7 +68,7 @@ use Illuminate\Support\Arr;
           }
 
           // user_idに紐づいてるtreatmentとpatient情報を取得
-          $all = Schedule::with('treatment','patient')
+          $all = Schedule::with('user','treatment','patient')
           ->whereIn('user_id',$usersId)
           ->get();
 

--- a/app/Schedule.php
+++ b/app/Schedule.php
@@ -12,6 +12,11 @@ class Schedule extends Model
   public $incrementing = false;
   protected $fillable = ['user_id', 'patient_id', 'treatment_id'];
   
+  public function user()
+  {
+    return $this->belongsTo('App\user');
+  }
+
   public function treatment()
   {
     return $this->belongsTo('App\treatment');

--- a/app/User.php
+++ b/app/User.php
@@ -40,6 +40,11 @@ class User extends Authenticatable
     ];
 
 
+    public function schedules()
+    {
+      return $this->belongsToMany('App\Schedule');
+    }
+
     public function patients()
     {
       return $this->belongsToMany('App\Patient');

--- a/resources/js/components/pages/leader/ScheduleList.vue
+++ b/resources/js/components/pages/leader/ScheduleList.vue
@@ -40,6 +40,7 @@
                 <!-- ▼カレンダー設定 -->
                 <v-sheet height="600">
                     <v-calendar
+                        class="test"
                         ref="calendar"
                         v-model="focus"
                         color="primary"
@@ -49,12 +50,12 @@
                         :events="events"
                         :event-color="getEventColor"
                         :event-ripple="false"
-                        @change="fetchEvents"
                         @mousedown:event="startDrag"
                         @mousedown:time-category="startTime"
-                        @mousemove:time="mouseMove"
+                        @mousemove:time-category="mouseMove"
                         @mouseup:time="endDrag"
                         @mouseleave.native="cancelDrag"
+                        @click:event="showEvent"
                     >
                         <!-- nowライン設定 -->
                         <template #day-body="{ date, week }">
@@ -83,14 +84,37 @@
             </v-col>
         </v-row>
         <!-- ▲カレンダーここまで -->
+        <!-- クリック時に開く詳細画面 -->
+        <v-card
+            v-if="selectedOpen"
+            min-width="350px"
+            flat
+            class="detail-schedule"
+        >
+            <v-card-text>
+                <p>{{ selectedEvent.category }}</p>
+                <p>{{ selectedEvent.patient }}</p>
+                <p>{{ selectedEvent.name }}</p>
+                <MomentJs :time="selectedEvent.start" />
+            </v-card-text>
+            <v-card-actions>
+                <v-btn text color="secondary" @click="selectedOpen = false">
+                    閉じる
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+        <!-- クリック時に開く詳細画面 ここまで-->
     </div>
 </template>
 <script>
 // コンポーネントのインポート
+import MomentJs from "../../items/MomentJs";
 
 // Vue
 export default {
-    components: {},
+    components: {
+        MomentJs
+    },
     data: () => ({
         staffs: [],
         // ▼カレンダー関連
@@ -104,19 +128,15 @@ export default {
         createStart: null,
         extendOriginal: null,
         //   イベントで使用するデータ
-        focus: "", 
+        focus: "",
         events: [], //ここを表示
-        colors: [
-            "blue",
-            "indigo",
-            "deep-purple",
-            "cyan",
-            "green",
-            "orange",
-            "grey darken-1"
-        ],
+        colors: ["blue"], // テスト用
         names: ["テスト", "テスト2"], // スケジュールの名前
-        categories: [],//患者の名前
+        categories: [], //患者の名前
+        // スケジュール詳細
+        selectedEvent: {},
+        selectedElement: null,
+        selectedOpen: false
     }),
     created() {
         this.fetchStaff();
@@ -146,13 +166,9 @@ export default {
             axios
                 .get("/api/team_users/get/all/" + this.$route.params.team_id)
                 .then(res => {
-                    console.log("status:", res.status);
-                    console.log("body:", res.data);
                     this.staffs = res.data;
                     //   カレンダー表記用の配列に格納
                     this.categories = this.staffs.map(el => el.name);
-                    //  イベントを取得
-                    this.fetchEvents();
                 })
                 .catch(err => {
                     console.log(err);
@@ -163,12 +179,12 @@ export default {
             axios
                 .get("/api/schedules/get/team")
                 .then(res => {
-                    console.log("status:", res.status);
-                    console.log("body:", res.data);
                     this.schedules = res.data;
+                    //  イベントを取得
+                    this.fetchEvents();
                 })
                 .catch(err => {
-                    console.log("err:", err);
+                    console.log("err:", err.response.data);
                 });
         },
         // ---------- スケジュール表示関連 ---------- //
@@ -193,36 +209,32 @@ export default {
         // イベント登録
         fetchEvents() {
             const events = [];
-            for (let i = 0; i < 1; i++) {
-                // timestamp例
-                const dt = new Date();
-                // 現在時刻
-                const nowdate = Date.now();
-                // 現在時刻から10分後
-                const enddate = dt.setMinutes(dt.getMinutes() + 30);
+            const eventCount = this.schedules.length;
+            for (let i = 0; i < eventCount; i++) {
+                // 開始時間と終了時刻の定義
+                const startdate = new Date(this.schedules[i].start_date);
+                const requiredTime = this.schedules[i].treatment.time_required;
+                const addition_time = requiredTime * 60 * 1000;
+                const endTime = startdate.getTime() + addition_time;
                 // イベントにpush < テストデータ
                 events.push({
-                    name: this.names[0], // 処置の名前
-                    start: nowdate, // 開始時刻
-                    end: enddate, // 終了時刻
-                    color: this.colors[0], // 色
+                    category: this.schedules[i].user.name, //スタッフの名前
+                    name:
+                        this.schedules[i].patient.name +
+                        " / " +
+                        this.schedules[i].treatment.name, // 処置の名前
+                    start: startdate, // 開始時刻
+                    end: endTime, // 終了時刻
+                    color: this.colors[0], //デフォルトのカラー
                     timed: true,
-                    //   人の名前
-                    category: this.categories[0]
-                });
-                // イベントにpush < テストデータ
-                events.push({
-                    name: this.names[0], // 処置の名前
-                    start: nowdate, // 開始時刻
-                    end: enddate, // 終了時刻
-                    color: this.colors[1], // 色
-                    timed: true,
-                    //   人の名前
-                    category: this.categories[1]
+                    id: this.schedules[i].id,
+                    room: this.schedules[i].patient.room,
+                    treatment: this.schedules[i].treatment.name,
+                    patient: this.schedules[i].patient.name
                 });
             }
-            console.log(events);
             this.events = events;
+            console.log(this.events);
         },
         // -----------  イベント取得&表示ここまで ---------- //
 
@@ -253,7 +265,6 @@ export default {
         },
         startTime(tms) {
             const mouse = this.toTime(tms);
-            console.log(tms);
             if (this.dragEvent && this.dragTime === null) {
                 const start = this.dragEvent.start;
 
@@ -289,9 +300,11 @@ export default {
                 const newStartTime = mouse - this.dragTime;
                 const newStart = this.roundTime(newStartTime);
                 const newEnd = newStart + duration;
-
+                const category = tms.category;
                 this.dragEvent.start = newStart;
                 this.dragEvent.end = newEnd;
+                // カテゴリー追加
+                this.dragEvent.category = category;
             }
             // イベント作成中
             else if (this.createEvent && this.createStart !== null) {
@@ -349,9 +362,30 @@ export default {
         },
         rndElement(arr) {
             return arr[this.rnd(0, arr.length - 1)];
+        },
+        // ------------ Drag and Dropここまで ---------- //
+
+        // ------------ クリックしたときの詳細画面 ---------- //
+        showEvent({ nativeEvent, event }) {
+            const open = () => {
+                this.selectedEvent = event;
+                this.selectedElement = nativeEvent.target;
+                console.log(event);
+
+                setTimeout(() => (this.selectedOpen = true), 10);
+            };
+
+            if (this.selectedOpen) {
+                this.selectedOpen = false;
+                setTimeout(open, 10);
+            } else {
+                open();
+            }
+
+            nativeEvent.stopPropagation();
         }
+        // ------------ クリックしたときの詳細画面 ここまで ---------- //
     }
-    // ------------ Drag and Dropここまで ---------- //
 };
 </script>
 
@@ -365,17 +399,17 @@ export default {
     left: -1px;
     right: 0;
     pointer-events: none;
-    // ↓丸いポイントが出る
-    //   &.first::before {
-    //     content: "";
-    //     position: absolute;
-    //     background-color: #ea4335;
-    //     width: 12px;
-    //     height: 12px;
-    //     border-radius: 50%;
-    //     margin-top: -5px;
-    //     margin-left: -6.5px;
-    //   }
+    //     // ↓丸いポイントが出る
+    //     //   &.first::before {
+    //     //     content: "";
+    //     //     position: absolute;
+    //     //     background-color: #ea4335;
+    //     //     width: 12px;
+    //     //     height: 12px;
+    //     //     border-radius: 50%;
+    //     //     margin-top: -5px;
+    //     //     margin-left: -6.5px;
+    //     //   }
 }
 // Drag and Drop
 .v-event-draggable {
@@ -386,6 +420,9 @@ export default {
     user-select: none;
     -webkit-user-select: none;
 }
+// .test {
+//     position: relative;
+// }
 
 .v-event-drag-bottom {
     position: absolute;
@@ -412,4 +449,17 @@ export default {
         display: block;
     }
 }
+
+/* スケジュール詳細のスタイル */
+.detail-schedule {
+    position: fixed;
+    bottom: 56px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 250px;
+    z-index: 5;
+    background: #fff;
+}
+/* スケジュール詳細のスタイル　ここまで */
 </style>


### PR DESCRIPTION
# やったこと
- スタッフのスケジュール一覧表示
→APIで全スタッフのデータを返却してるので、テーブル変更が終わり次第修正します
- イベントを自由自在に動かせる
- クリックで詳細表示（辻さんの丸々コピペ）

# これからやること
- スケジュール取得のAPI変更（上記）
- 予定の変更または追加の処理実装