### PR TITLE
スタッフによる新規スケジュール登録実装

### DIFF
--- a/app/Http/Controllers/Api/TasksController.php
+++ b/app/Http/Controllers/Api/TasksController.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Arr;
     
     class TasksController extends Controller
     {
-      // 新規スケジュール登録 (スタッフ)
+      // 新規<複数>スケジュール登録 (スタッフ)
     public function addTasks(Request $request,$shcedule_id) 
     {
       // $user = Auth::id();
@@ -29,11 +29,10 @@ use Illuminate\Support\Arr;
         $task->start_date = $val['start_date'];
         $task->save();
       }
-
       return $request->all();
     }
-      // 新規スケジュール登録 (リーダー)
-    public function addLeaderTask(Request $request) 
+      // 新規スケジュール登録 
+    public function addNewTask(Request $request) 
     {
       // $user = Auth::id();
       $task = new Task;

--- a/resources/js/components/pages/leader/ScheduleList.vue
+++ b/resources/js/components/pages/leader/ScheduleList.vue
@@ -293,8 +293,9 @@ export default {
         this.today + " " + setTime.HH + ":" + setTime.mm + ":00";
       this.registEvent.start_date = startTime;
       axios
-        .post(`/api/tasks/post/leader`, this.registEvent)
+        .post(`/api/tasks/post/new`, this.registEvent)
         .then(res => {
+          this.registOpen = false;
           this.fetchSchedule();
         })
         .catch(err => {
@@ -411,7 +412,7 @@ export default {
 
         this.dragTime = mouse - start;
       } else {
-        // 👷‍♂️イベント追加処理
+        // イベント追加処理
         tms.start = this.roundTime(mouse);
         this.showRegistEvent(tms);
         this.createStart = this.roundTime(mouse);

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,14 +99,12 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 
   // -----task_table_API-----
-    // リーダーによるタスクデータの登録
-    Route::post('/tasks/post/leader','Api\TasksController@addLeaderTask'); 
+    // タスクデータの登録
+    Route::post('/tasks/post/new','Api\TasksController@addNewTask'); 
     
-  // 看護師によるタスクデータの登録
-  Route::post('/tasks/post/{schedule_id}','Api\TasksController@addtasks'); 
-  
+  // 看護師による<複数>タスクデータの登録
+  Route::post('/tasks/post/{task_id}','Api\TasksController@addtasks'); 
 
-  
   // 登録タスク取得
   Route::get('/tasks/get/all/{schedule_id}','Api\TasksController@getTasks');
 


### PR DESCRIPTION
# やったこと
- スタッフのスケジュール一覧から、空間クリック→プルダウンで患者,処置,時刻を選択→登録できます

# メモ
- APIは、リーダーによる新規登録で使ったものを使い回してますが、特に問題はなさそうです