### PR TITLE
リーダーフッター設定、リンク切れ修正

### DIFF
--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -9,6 +9,9 @@
         <!-- フッターコンポーネント読み込み -->
         <footer-component v-if="$route.name !== 'SelectRole' && $route.name !== 'SelectStaff' && $route.name !== 'SelectPatients' 
                              && $route.name !== 'RegistSchedule' && $route.name !== 'RegistTreatmentSchedule'"></footer-component>
+        <leader-footer-component v-if="$route.name !== 'SelectRole' && $route.name !== 'SelectStaff' && $route.name !== 'SelectPatients' 
+                             && $route.name !== 'RegistSchedule' && $route.name !== 'RegistTreatmentSchedule' && $route.name !== 'StaffSchedule'
+                              && $route.name !== 'PatientSchedule' && $route.name !== 'SelectStaff'"></leader-footer-component>
 
     </v-app>
 </template>
@@ -16,12 +19,15 @@
 <script>
 import HeaderComponent from "./items/HeaderComponent.vue";
 import FooterComponent from "./items/FooterComponent.vue";
+import LeaderFooterComponent from "./items/LeaderFooterComponent.vue";
+
 
 // 全ページ共通のコンポーネント読み込み
 export default {
     components: {
         HeaderComponent,
-        FooterComponent
+        FooterComponent,
+        LeaderFooterComponent
     }
 };
 </script>

--- a/resources/js/components/items/LeaderFooterComponent.vue
+++ b/resources/js/components/items/LeaderFooterComponent.vue
@@ -1,0 +1,37 @@
+<template>
+<!-- 仮フッター -->
+    <v-bottom-navigation
+    grow
+    color="blue lighten-1"
+    fixed absolute
+  >
+    <v-btn :to="{ name: 'ScheduleList' }">
+      <span>スタッフスケジュール</span>
+      <v-icon>mdi-history</v-icon>
+    </v-btn>
+
+    <v-btn :to="{ name: 'TreatmentList' }">
+      <span>処置一覧</span>
+      <v-icon>mdi-account-group</v-icon>
+    </v-btn>
+
+    <v-btn :to="{ name: 'PatientsList' }">
+      <span>患者一覧</span>
+      <v-icon>mdi-account-group</v-icon>
+    </v-btn>
+
+  </v-bottom-navigation>
+</template>
+<script>
+export default {
+    components: {},
+    data: () => ({bottomNav: 'recent'}),
+    created() {},
+    computed: {},
+    methods: {}
+};
+</script>
+
+<style lang="scss" scoped>
+/* スコープ付きのスタイル */
+</style>

--- a/resources/js/components/pages/staff/SelectRole.vue
+++ b/resources/js/components/pages/staff/SelectRole.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- 仮オブジェクト -->
-  <div　ontouchstart=””>
+  <div>
     <v-app-bar flat color="white" fixed light>
       <!--ここにログアウト付けたかった -->
       <span @click="logout" style="cursor: pinter; color:#2196F3;" >＜ 戻る</span>
@@ -36,6 +36,7 @@
         width="260"
         class="button"
         color="#ff8000"
+        @click="postSchedule()"
       >スタッフ</v-btn>
     </div>
     <!-- ▲スタッフボタンここまで -->


### PR DESCRIPTION
・リーダーのフッター設定（スケジュール、処置設定、患者設定）
・役割選択のスタッフリンクを誤って削除していたため修正

＜残タスク＞
・フッターのスタッフスケジュールボタンが常にactiveになってしまう