### PR TITLE
担当患者/チームメンバーの選択で戻る押してもデータを維持

### DIFF
--- a/app/Http/Controllers/Api/TasksController.php
+++ b/app/Http/Controllers/Api/TasksController.php
@@ -68,12 +68,11 @@ use Illuminate\Support\Arr;
           // user_idからshcedule_id取得 < 最新のschedule_id取得
           $schedules = [];
           foreach($userIds as $val){
-          $shcedule = Schedule::where('user_id',$val)
-                        ->orderBy('id','desc')
-                        ->first()
-                        ->id;
-            array_push($schedules,$shcedule);
-          } 
+              $shcedule = Schedule::where('user_id',$val)
+                            ->orderBy('id','desc')
+                            ->first();
+                array_push($schedules,optional($shcedule)->id);
+          }
           // schedule_idに紐づいてるtreatmentとpatient情報を取得
           $all = Task::with('treatment','patient')
           ->whereIn('schedule_id',$schedules)

--- a/app/Http/Controllers/Api/TeamUsersController.php
+++ b/app/Http/Controllers/Api/TeamUsersController.php
@@ -15,9 +15,14 @@ use Illuminate\Support\Arr;
     class TeamUsersController extends Controller
     {
       // チームメンバー登録
-      public function addTeamUser(Request $request) 
+      public function addTeamUser(Request $request,$team_id) 
         {
           $leader_id = Auth::id();
+          // 既に登録されている場合は削除して登録し直す
+          $pre_TeamUsers = TeamUser::where('team_id',$team_id)->get();
+          if($pre_TeamUsers){
+            TeamUser::where('team_id',$team_id)->delete();
+          }
           // 配列処理
           foreach($request->id as $val)
           {

--- a/app/Http/Controllers/Api/UsersPatientsController.php
+++ b/app/Http/Controllers/Api/UsersPatientsController.php
@@ -14,33 +14,38 @@ use App\Task;
     class UsersPatientsController extends Controller
     {
 
-
     // 担当患者登録
-        public function addUsersPatients(Request $request) 
+        public function addUsersPatients(Request $request,$schedule_id) 
         {
           $user = Auth::id();
           $ids = $request->id;
+          // 既に登録されている場合は削除して登録し直す
+          $pre_UsersPatients = UsersPatient::where('schedule_id',$schedule_id)->get();
+          if($pre_UsersPatients){
+            UsersPatient::where('schedule_id',$schedule_id)->delete();
+          }
           foreach ($ids as $val) {
           $usersPatients = new UsersPatient;
-          $usersPatients->schedule_id =Schedule::orderBy('created_at', 'desc')
-          ->where('user_id',$user)
-          ->first()
-          ->id;
+          $usersPatients->schedule_id = $schedule_id;
+          // Schedule::orderBy('created_at', 'desc')
+          // ->where('user_id',$user)
+          // ->first()
+          // ->id;
           $usersPatients->patient_id = $val;
           $usersPatients->save();
           }
         }
     
      // ログイン中の担当患者取得
-        public function getUsersPatients()
+        public function getUsersPatients($schedule_id)
         { 
           $user = Auth::id();
-          $scheduleId = Schedule::orderBy('created_at', 'desc')
-          ->where('user_id',$user)
-          ->first()
-          ->id;
+          // $scheduleId = Schedule::orderBy('created_at', 'desc')
+          // ->where('user_id',$user)
+          // ->first()
+          // ->id;
           $allusersPatients = UsersPatient::with('patient')
-          ->where('schedule_id',$scheduleId)
+          ->where('schedule_id',$schedule_id)
           ->get();
           $usersPatients = $allusersPatients->pluck('patient');
           return $usersPatients;

--- a/app/TeamUser.php
+++ b/app/TeamUser.php
@@ -3,9 +3,12 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class TeamUser extends Model
 {
+  use SoftDeletes;
+
   protected $guarded = ["id"];
   protected $table = 'team_users';
   protected $primaryKey = ['user_id', 'team_id'];

--- a/app/UsersPatient.php
+++ b/app/UsersPatient.php
@@ -3,9 +3,12 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class UsersPatient extends Model
 {
+  use SoftDeletes;
+
   // protected $guarded = ["id"];
   // protected $table = 'users_patients';
   // protected $primaryKey = ['schedule_id','patient_id'];

--- a/resources/js/components/pages/leader/ScheduleList.vue
+++ b/resources/js/components/pages/leader/ScheduleList.vue
@@ -5,7 +5,9 @@
       <v-col>
         <v-sheet height="64">
           <v-toolbar flat color="white">
-            <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">Today</v-btn>
+            <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday"
+              >Today</v-btn
+            >
             <v-btn fab text small color="grey darken-2" @click="prev">
               <v-icon small>mdi-chevron-left</v-icon>
             </v-btn>
@@ -13,9 +15,7 @@
               <v-icon small>mdi-chevron-right</v-icon>
             </v-btn>
             <v-toolbar-title v-if="$refs.calendar">
-              {{
-              $refs.calendar.title
-              }}
+              {{ $refs.calendar.title }}
             </v-toolbar-title>
             <v-spacer></v-spacer>
           </v-toolbar>
@@ -51,7 +51,7 @@
             </template>
             <!-- nowライン設定ここまで -->
             <!-- ドラック&ドロップ設定 -->
-            <template #event="{ event, timed,eventSummary}">
+            <template #event="{ event, timed, eventSummary }">
               <div class="v-event-draggable" v-html="eventSummary()"></div>
               <!-- <div
                                 v-if="timed"
@@ -85,7 +85,9 @@
         <v-btn @click="updateSchedule()">変更</v-btn>
       </v-card-text>
       <v-card-actions>
-        <v-btn text color="secondary" @click="selectedOpen = false">閉じる</v-btn>
+        <v-btn text color="secondary" @click="selectedOpen = false"
+          >閉じる</v-btn
+        >
       </v-card-actions>
     </v-card>
     <!-- タスククリック時に開く詳細画面 ここまで-->
@@ -103,7 +105,9 @@
               v-for="patient in patients"
               :value="patient.id"
               :key="patient.id"
-            >{{ patient.name }}</option>
+            >
+              {{ patient.name }}
+            </option>
           </select>
         </div>
         <p>処置</p>
@@ -114,7 +118,9 @@
               v-for="treatment in treatments"
               :value="treatment.id"
               :key="treatment.id"
-            >{{ treatment.name }}</option>
+            >
+              {{ treatment.name }}
+            </option>
           </select>
         </div>
         <p>時間</p>
@@ -149,7 +155,7 @@ import "vue2-timepicker/dist/VueTimepicker.css";
 export default {
   components: {
     MomentJs,
-    "vue-timepicker": VueTimepicker
+    "vue-timepicker": VueTimepicker,
   },
   data: () => ({
     staffs: [],
@@ -179,7 +185,7 @@ export default {
     // スケジュール新規作成
     registEvent: {},
     registElement: null,
-    registOpen: false
+    registOpen: false,
   }),
   created() {
     this.fetchStaff();
@@ -194,7 +200,7 @@ export default {
     },
     nowY() {
       return this.cal ? this.cal.timeToY(this.cal.times.now) + "px" : "-10px";
-    }
+    },
   },
   mounted() {
     this.setToday();
@@ -207,33 +213,34 @@ export default {
   },
   methods: {
     // 【API】スタッフを取得
-    fetchStaff: function() {
+    fetchStaff: function () {
       axios
         .get("/api/team_users/get/all/" + this.$route.params.team_id)
-        .then(res => {
+        .then((res) => {
           this.staffs = res.data;
           //   カレンダー表記用の配列に格納
-          this.categories = this.staffs.map(el => el.name);
+          this.categories = this.staffs.map((el) => el.name);
         })
-        .catch(err => {
+        .catch((err) => {
           console.log(err.response.data);
         });
     },
     // 【API】スケジュールを取得
-    fetchSchedule: function() {
+    fetchSchedule: function () {
       axios
         .get(`/api/tasks/get/team/${this.$route.params.team_id}`)
-        .then(res => {
+        .then((res) => {
           this.schedules = res.data;
+          console.log(res.data);
           //  イベントを取得
           this.fetchEvents();
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err.response.data);
         });
     },
     // 【API】スケジュール登録更新
-    updateSchedule: function() {
+    updateSchedule: function () {
       this.postScheduleData = this.selectedEvent;
       // 時刻の整形
       const setTime = this.postScheduleData.update_time;
@@ -248,40 +255,40 @@ export default {
       const task_id = this.postScheduleData.task_id;
       axios
         .post(`/api/tasks/update/leader/${task_id}`, this.postScheduleData)
-        .then(res => {
+        .then((res) => {
           // 描画し直し
           this.fetchSchedule();
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err.response.data);
         });
     },
     // 【API】処置取得
-    fetchTreatment: function() {
+    fetchTreatment: function () {
       axios
         .get("/api/treatments/get/all")
-        .then(res => {
+        .then((res) => {
           this.treatments = res.data;
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err);
         });
     },
     // 【API】患者取得
-    fetchPatients: function() {
+    fetchPatients: function () {
       axios
         .get("/api/patients/get/all")
-        .then(res => {
+        .then((res) => {
           this.patients = res.data;
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err);
         });
     },
     // 【API】新規タスク登録
-    registTask: function() {
+    registTask: function () {
       // schedule_idを取得して格納
-      const target = this.staffs.find(el => {
+      const target = this.staffs.find((el) => {
         return el.name === this.registEvent.category;
       });
       this.registEvent.schedule_id = target.schedule.id;
@@ -292,16 +299,16 @@ export default {
       this.registEvent.start_date = startTime;
       axios
         .post(`/api/tasks/post/new`, this.registEvent)
-        .then(res => {
+        .then((res) => {
           this.registOpen = false;
           this.fetchSchedule();
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err.response.data);
         });
     },
     // DB保存用に日付を整形
-    setDatetime: function() {
+    setDatetime: function () {
       var today = new Date();
       var year = today.getFullYear();
       var month = today.getMonth() + 1;
@@ -367,7 +374,7 @@ export default {
           timed: true,
           room: this.schedules[i].patient.room,
           treatment: this.schedules[i].treatment.name,
-          patient: this.schedules[i].patient.name
+          patient: this.schedules[i].patient.name,
         });
       }
       this.events = events;
@@ -461,23 +468,17 @@ export default {
     endDrag() {
       // *スタッフ間を移動した場合に、postデータのschedule_idを変更
       if (this.selectedStaff !== this.dragEvent.category) {
-        const target = this.staffs.find(el => {
+        const target = this.staffs.find((el) => {
           return el.name === this.dragEvent.category;
         });
         this.selectedEvent.schedule_id = target.schedule.id;
       }
       const update_time = new Date(this.selectedEvent.start);
-      const hour = update_time
-        .getHours()
-        .toString()
-        .padStart(2, "0");
-      const minutes = update_time
-        .getMinutes()
-        .toString()
-        .padStart(2, "0");
+      const hour = update_time.getHours().toString().padStart(2, "0");
+      const minutes = update_time.getMinutes().toString().padStart(2, "0");
       this.selectedEvent.update_time = {
         HH: hour,
-        mm: minutes
+        mm: minutes,
       };
       // 更新
       this.updateSchedule();
@@ -556,17 +557,11 @@ export default {
         this.registEvent.category = event.category;
         // 時刻を整形
         const update_time = new Date(event.start);
-        const hour = update_time
-          .getHours()
-          .toString()
-          .padStart(2, "0");
-        const minutes = update_time
-          .getMinutes()
-          .toString()
-          .padStart(2, "0");
+        const hour = update_time.getHours().toString().padStart(2, "0");
+        const minutes = update_time.getMinutes().toString().padStart(2, "0");
         this.registEvent.start_time = {
           HH: hour,
-          mm: minutes
+          mm: minutes,
         };
         // this.registElement = nativeEvent.target;
         setTimeout(() => (this.registOpen = true), 10);
@@ -580,9 +575,9 @@ export default {
       }
 
       //   nativeEvent.stopPropagation();
-    }
+    },
     // ------------ タスク作成時の詳細画面 ここまで ---------- //
-  }
+  },
 };
 </script>
 

--- a/resources/js/components/pages/leader/SelectStaff.vue
+++ b/resources/js/components/pages/leader/SelectStaff.vue
@@ -1,29 +1,9 @@
 <template>
-  <!-- <v-card>
-        <v-list-item>
-            <v-list-item-content>
-                <v-list-item-title>【リーダー】スタッフ一覧</v-list-item-title>
-                <ul>
-                    <li v-for="staff in staffs" v-bind:key="staff.id">
-                        {{ staff.name }}
-                    </li>
-                </ul>
-
-                <v-text-field v-model="staffs.id"></v-text-field>
-                <v-btn
-                    class="ma-2"
-                    outlined
-                    color="pink lighten-1"
-                    @click="select(staffs.id)"
-                >
-                    決定
-                </v-btn>
-            </v-list-item-content>
-        </v-list-item>
-  </v-card>-->
   <v-item-group multiple v-model="saveSelecyedStaff">
     <v-container>
-      <v-list-item-title class="center">本日のチームスタッフを全て選択してください</v-list-item-title>
+      <v-list-item-title class="center"
+        >本日のチームスタッフを全て選択してください</v-list-item-title
+      >
       <v-row>
         <v-col v-for="staff in staffs" :key="staff.id" cols="6">
           <v-item v-slot:default="{ active, toggle }" :value="staff.id">
@@ -38,9 +18,8 @@
               >
                 <v-card-text>
                   <div>〇〇科 {{ staff.id }}</div>
-                  <p class="name">{{staff.name}} Ns</p>
+                  <p class="name">{{ staff.name }} Ns</p>
                 </v-card-text>
-
                 <v-scroll-y-transition>
                   <div v-if="active" class="display-3 flex-grow-1"></div>
                 </v-scroll-y-transition>
@@ -49,8 +28,6 @@
           </v-item>
         </v-col>
       </v-row>
-
-      {{saveSelecyedStaff}}
       <v-footer fixed class="font-weight-medium footer">
         <v-btn
           class="mx-auto my-2 px-12 py-4 submit_btn"
@@ -61,7 +38,8 @@
           width="220"
           type="submit"
           @click="pushSelectedData()"
-        >決定</v-btn>
+          >決定</v-btn
+        >
       </v-footer>
     </v-container>
   </v-item-group>
@@ -72,42 +50,59 @@ export default {
   components: {},
   data: () => ({
     staffs: [],
-    saveSelecyedStaff: []
+    saveSelecyedStaff: [],
   }),
   methods: {
-    fetchStaff: function() {
+    // 【API】全スタッフ取得
+    fetchStaff: function () {
       axios
         .get("/api/users/get/all")
-        .then(res => {
+        .then((res) => {
           this.staffs = res.data;
         })
-        .catch(err => {
+        .catch((err) => {
           console.log("err:", err);
         });
     },
-    pushSelectedData: function() {
+    // 【API】チームスタッフ取得
+    fetchTeamStaff: function () {
       axios
-        .post("/api/team_users/add/", {
-          id: this.saveSelecyedStaff
+        .get("/api/team_users/get/all/" + this.$route.params.team_id)
+        .then((res) => {
+          console.log(res.data);
+          res.data.forEach((el) => {
+            this.saveSelecyedStaff.push(el.id);
+          });
         })
-        .then(res => {
+        .catch((err) => {
+          console.log(err.response.data);
+        });
+    },
+    // 【API】スタッフ登録
+    pushSelectedData: function () {
+      axios
+        .post(`/api/team_users/add/${this.$route.params.team_id}`, {
+          id: this.saveSelecyedStaff,
+        })
+        .then((res) => {
           this.staffs = res.data;
           // ページ遷移
           this.$router.push({
             name: "ScheduleList",
-            params:{
-              team_id:this.$route.params.team_id
-            }
+            params: {
+              team_id: this.$route.params.team_id,
+            },
           });
         })
-        .catch(err => {
-          console.log(err.response.data)
+        .catch((err) => {
+          console.log(err.response.data);
         });
-    }
+    },
   },
   created() {
     this.fetchStaff();
-  }
+    this.fetchTeamStaff();
+  },
 };
 </script>
 

--- a/resources/js/components/pages/staff/RegistTreatmentSchedule.vue
+++ b/resources/js/components/pages/staff/RegistTreatmentSchedule.vue
@@ -162,7 +162,7 @@ export default {
   methods: {
     fetchPatients: function() {
       axios
-        .get("/api/users_patients/get/all")
+        .get(`/api/users_patients/get/all/${this.$route.params.schedule_id}`)
         .then(res => {
           // console.log("status:", res.status);
           // console.log("body:", res.data);

--- a/resources/js/components/pages/staff/SelectPatients.vue
+++ b/resources/js/components/pages/staff/SelectPatients.vue
@@ -1,237 +1,200 @@
 <template>
-    <!-- 仮オブジェクト -->
-    <!--<v-card>
-        <v-list-item>
-            <v-list-item-content>
-                <v-list-item-title>【スタッフ】患者選択</v-list-item-title>
-                <ul>
-                    <li v-for="patient in patients" v-bind:key="patient.id">
-                        <span>{{ patient.room }}号室</span>
-                        <p>{{ patient.name }}さん
-                        <span v-if="patient.sex　== 1">男</span>
-                        <span v-else>女</span>
-                        {{ patient.birthday }}
-                        {{ today }}
+  <v-item-group multiple v-model="saveSelectedPatient">
+    <v-container>
+      <v-stepper value="1" alt-labels>
+        <v-stepper-header>
+          <v-stepper-step step="1" color="#5e9ce6">患者選択</v-stepper-step>
 
-                        </p>
-                         dbには誕生日登録してるけど表示は年齢にしたい！ 
-                        
-                        {{ patient.hospitalization_date }}
-                        {{ patient.surgery_date }}
-                        <p>{{ patient.memo }}</p>
-                    </li>
-                </ul>
-                <v-text-field v-model="patients.id"></v-text-field>
-                <v-btn
-                    class="ma-2"
-                    outlined
-                    color="pink lighten-1"
-                    @click="select(patients.id)"
-                >
-                    決定
-                </v-btn>
-            </v-list-item-content>
-        </v-list-item>
-    </v-card>-->
-    <!-- ここまで -->
+          <v-divider></v-divider>
 
-    <v-item-group multiple v-model="saveSelectedPatient">
-        <v-container>
-            <v-stepper value="1" alt-labels>
-                <v-stepper-header>
-                    <v-stepper-step step="1" color="#5e9ce6">患者選択</v-stepper-step>
+          <v-stepper-step step="2">処置選択</v-stepper-step>
 
-                    <v-divider></v-divider>
+          <v-divider></v-divider>
 
-                    <v-stepper-step step="2">処置選択</v-stepper-step>
+          <v-stepper-step step="3">スケジュール調整</v-stepper-step>
+        </v-stepper-header>
+      </v-stepper>
 
-                    <v-divider></v-divider>
+      <v-list-item-title class="center pt-0"
+        >本日の担当の患者さんを全て選択してください</v-list-item-title
+      >
+      <v-row>
+        <v-col v-for="patient in patients" :key="patient.id" cols="6">
+          <v-item v-slot:default="{ active, toggle }" :value="patient.id">
+            <v-hover v-slot:default="{ hover }">
+              <v-card
+                :color="active ? '#62ABF8' : ''"
+                class="d-flex align-center"
+                :class="{ 'on-hover': hover }"
+                outlined
+                height="230"
+                @click="toggle"
+              >
+                <v-card-text>
+                  <p class="ma-0">{{ patient.room }}号室</p>
+                  <p class="ma-0">
+                    {{ patient.name }}さん
+                    <span v-if="patient.sex == 1" class="ml-2">男性</span>
+                    <span v-else-if="patient.sex == 2" class="ml-2">女性</span>
+                    <span v-else class="ml-2">性別未記入</span>
+                  </p>
+                  <BirthDayMomentJs :time="patient.birthday"></BirthDayMomentJs>
+                  <p class="ma-0">
+                    <span>入院日：</span>{{ patient.hospitalization_date }}
+                  </p>
+                  <p class="ma-0">
+                    <span>手術日：</span>{{ patient.surgery_date }}
+                  </p>
+                  <p class="ma-0">特記事項</p>
+                  <p class="ma-0">{{ patient.memo }}</p>
+                </v-card-text>
 
-                    <v-stepper-step step="3">スケジュール調整</v-stepper-step>
-                </v-stepper-header>
-            </v-stepper>
-
-            <v-list-item-title class="center pt-0"
-                >本日の担当の患者さんを全て選択してください</v-list-item-title
-            >
-            <v-row>
-                <v-col v-for="patient in patients" :key="patient.id" cols="6">
-                    <v-item
-                        v-slot:default="{ active, toggle }"
-                        :value="patient.id"
-                    >
-                        <v-hover v-slot:default="{ hover }">
-                            <v-card
-                                :color="active ? '#62ABF8' : ''"
-                                class="d-flex align-center"
-                                :class="{ 'on-hover': hover }"
-                                outlined
-                                height="230"
-                                @click="toggle"
-                            >
-                                <v-card-text>
-                                    <p class="ma-0">{{ patient.room }}号室</p>
-                                    <p class="ma-0">
-                                        {{ patient.name }}さん
-                                        <span
-                                            v-if="patient.sex == 1"
-                                            class="ml-2"
-                                            >男性</span
-                                        >
-                                        <span
-                                            v-else-if="patient.sex == 2"
-                                            class="ml-2"
-                                            >女性</span
-                                        >
-                                        <span v-else class="ml-2"
-                                            >性別未記入</span
-                                        >
-                                    </p>
-                                    <BirthDayMomentJs
-                                        :time="patient.birthday"
-                                    ></BirthDayMomentJs>
-                                    <p class="ma-0">
-                                        <span>入院日：</span
-                                        >{{ patient.hospitalization_date }}
-                                    </p>
-                                    <p class="ma-0">
-                                        <span>手術日：</span
-                                        >{{ patient.surgery_date }}
-                                    </p>
-                                    <p class="ma-0">特記事項</p>
-                                    <p class="ma-0">{{ patient.memo }}</p>
-                                </v-card-text>
-
-                                <v-scroll-y-transition>
-                                    <div
-                                        v-if="active"
-                                        class="display-3 flex-grow-1"
-                                    ></div>
-                                </v-scroll-y-transition>
-                            </v-card>
-                        </v-hover>
-                    </v-item>
-                </v-col>
-            </v-row>
-            <!-- {{ saveSelectedPatient }} -->
-
-            <v-footer fixed class="font-weight-medium footer">
-                <v-btn
-                    class="mx-auto my-2 px-12 py-4 submit_btn"
-                    color="#62ABF8"
-                    rounded
-                    dark
-                    depressed
-                    width="220"
-                    type="submit"
-                    @click="pushSelectedData()"
-                    >決定</v-btn
-                >
-            </v-footer>
-        </v-container>
-    </v-item-group>
+                <v-scroll-y-transition>
+                  <div v-if="active" class="display-3 flex-grow-1"></div>
+                </v-scroll-y-transition>
+              </v-card>
+            </v-hover>
+          </v-item>
+        </v-col>
+      </v-row>
+      <!-- フッター -->
+      <v-footer fixed class="font-weight-medium footer">
+        <v-btn
+          class="mx-auto my-2 px-12 py-4 submit_btn"
+          color="#62ABF8"
+          rounded
+          dark
+          depressed
+          width="220"
+          type="submit"
+          @click="pushSelectedData()"
+          >決定</v-btn
+        >
+      </v-footer>
+    </v-container>
+  </v-item-group>
 </template>
 <script>
 // コンポーネントのインポート
 import BirthDayMomentJs from "../../items/BirthdayMomentJs";
 // Vue
 export default {
-    components: {
-        BirthDayMomentJs
+  components: {
+    BirthDayMomentJs,
+  },
+  data: () => ({
+    patients: [],
+    saveSelectedPatient: [],
+    usersPatients: [],
+    vertical: true,
+    e1: 1,
+  }),
+  methods: {
+    // 【API】患者一覧取得
+    fetchPatients: function () {
+      axios
+        .get("/api/patients/get/all")
+        .then((res) => {
+          this.patients = res.data;
+        })
+        .catch((err) => {
+          console.log("err:", err);
+        });
     },
-    data: () => ({
-        patients: [],
-        saveSelectedPatient: [],
-        usersPatients: [],
-        vertical: true,
-        e1: 1
-    }),
-    methods: {
-        fetchPatients: function() {
-            axios
-                .get("/api/patients/get/all")
-                .then(res => {
-                    console.log("status:", res.status);
-                    console.log("body:", res.data);
-                    this.patients = res.data;
-                })
-                .catch(err => {
-                    console.log("err:", err);
-                });
-        },
-
-        pushSelectedData: function() {
-            console.log(this.saveSelectedPatient);
-            axios
-                .post("/api/users_patients/add/", {
-                    id: this.saveSelectedPatient
-                })
-                .then(res => {
-                    console.log("status:", res.status);
-                    console.log("body:", res.data);
-                    this.usersPatients = res.data;
-                    const transitionDestinationObj = {
-                        name: "RegistTreatmentSchedule",
-                        params:{
-                            schedule_id: this.$route.params.schedule_id
-                        }
-                    };
-                    this.$router.push(transitionDestinationObj);
-                })
-                .catch(err => {
-                    "err:", err;
-                });
-        }
+    // 【API】患者登録
+    pushSelectedData: function () {
+      console.log(this.saveSelectedPatient);
+      axios
+        .post(`/api/users_patients/add/${this.$route.params.schedule_id}`, {
+          id: this.saveSelectedPatient,
+        })
+        .then((res) => {
+          this.usersPatients = res.data;
+          const transitionDestinationObj = {
+            name: "RegistTreatmentSchedule",
+            params: {
+              schedule_id: this.$route.params.schedule_id,
+            },
+          };
+          this.$router.push(transitionDestinationObj);
+        })
+        .catch((err) => {
+          console.log("err:", err.response.data);
+        });
     },
-    computed: {},
+    // 【API】担当患者取得
+    fetchUsersPatients: function () {
+      axios
+        .get(`/api/users_patients/get/all/${this.$route.params.schedule_id}`)
+        .then((res) => {
+          console.log("body:", res.data);
+          res.data.forEach((el) => {
+            this.saveSelectedPatient.push(el.id);
+          });
+        })
+        .catch((err) => {
+          console.log("err:", err);
+        });
+    },
+  },
+  computed: {},
 
-    created() {
-        this.fetchPatients();
-    }
+  created() {
+    this.fetchPatients();
+    this.fetchUsersPatients();
+  },
 };
 </script>
 
 <style scoped>
 /* スコープ付きのスタイル */
 .footer {
-    background: rgba(255, 0 0, 0.5);
+  background: rgba(255, 0 0, 0.5);
 }
 .name {
-    font-size: 17px;
+  font-size: 17px;
 }
 .center {
-    text-align: center;
-    padding: 1.2rem 0;
+  text-align: center;
+  padding: 1.2rem 0;
 }
 /* レイアウトが崩れるので一旦コメントアウトしてます */
 .theme--light.v-sheet--outlined {
-    /* border: solid 2px rgb(98, 171, 248, 0.9); */
+  /* border: solid 2px rgb(98, 171, 248, 0.9); */
 }
 
 .v-card:not(.on-hover) {
-    opacity: 0.8;
-    border: thin solid rgb(0, 0, 0, 0.12);
+  opacity: 0.8;
+  border: thin solid rgb(0, 0, 0, 0.12);
 }
 .v-stepper {
-    box-shadow: none;
+  box-shadow: none;
 }
 .v-stepper__header {
-    box-shadow: none;
+  box-shadow: none;
 }
 .v-stepper--alt-labels .v-stepper__header .v-divider {
-    margin: 22px -25px 0;
+  margin: 22px -25px 0;
 }
 .v-divider {
-    max-width: 90px;
+  max-width: 90px;
 }
 .v-stepper__step {
-    padding: 10px;
+  padding: 10px;
 }
 .v-stepper--alt-labels .v-stepper__step {
-    flex-basis: 100px;
+  flex-basis: 100px;
 }
-#app > div > main > div > div > div.v-stepper.v-stepper--vertical.v-stepper--alt-labels.theme--light > div > div.v-stepper__step.v-stepper__step--active > span{
-    margin-right: 0px;
+#app
+  > div
+  > main
+  > div
+  > div
+  > div.v-stepper.v-stepper--vertical.v-stepper--alt-labels.theme--light
+  > div
+  > div.v-stepper__step.v-stepper__step--active
+  > span {
+  margin-right: 0px;
 }
 </style>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,10 +58,10 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
   // -----users_patients_tabel API -----
   // 担当患者登録
-  Route::post('/users_patients/add','Api\UsersPatientsController@addUsersPatients'); 
+  Route::post('/users_patients/add/{schedule_id}','Api\UsersPatientsController@addUsersPatients'); 
 
   // 担当患者取得
-  Route::get('/users_patients/get/all','Api\UsersPatientsController@getUsersPatients'); 
+  Route::get('/users_patients/get/all/{schedule_id}','Api\UsersPatientsController@getUsersPatients'); 
 
   // 特定のuserの担当患者取得
   Route::get('/users_patients/get/{user_id}','Api\UsersPatientsController@getSelectUsersPatients');
@@ -91,7 +91,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
   // -----team_users_table API-----
   // チームメンバー登録  !済！
-  Route::post('/team_users/add','Api\TeamUsersController@addTeamUser'); 
+  Route::post('/team_users/add/{team_id}','Api\TeamUsersController@addTeamUser'); 
 
   // チームメンバー取得  !済！
   Route::get('/team_users/get/all/{team_id}','Api\TeamUsersController@getTeamUsers'); 


### PR DESCRIPTION
# やったこと
- 担当患者を選択後、戻るを押して登録し直せる
→既存データを論理削除して登録し直してます。もっと良い方法あるのかな...
- チームメンバーを選択後、戻るを押して登録し直せる
→上記と同様の処理です
- 別件ですが、リーダーがスケジュール未作成時のスタッフを選択するとバグってたので、修正しました
→PHPで、存在しないプロパティの値を参照（$schedule->idみたいな）しようとするとエラーをはくようになっているらしく、optional($shcedule)->id　とするとnullを返してくれるようになります