### PR TITLE
カレンダーページ修正など

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,7 +43,7 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            'throttle:60,1',
+            'throttle:600,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
         ],

--- a/database/seeds/PatientsTableSeeder.php
+++ b/database/seeds/PatientsTableSeeder.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Seeder;
             
             DB::table('patients')->insert([
                 "ward_id" => 1,
-                "name" => '佐藤智哉',
+                "name" => '山田太郎',
                 "birthday" => $faker->date()." ".$faker->time(),
                 "sex" => 1,
                 "room" => 101,
@@ -29,7 +29,7 @@ use Illuminate\Database\Seeder;
             ]);
             DB::table('patients')->insert([
                 "ward_id" => 1,
-                "name" => '崔　賀英',
+                "name" => '田中二郎',
                 "birthday" => $faker->date()." ".$faker->time(),
                 "sex" => 2,
                 "room" => 201,
@@ -70,7 +70,7 @@ use Illuminate\Database\Seeder;
  
             DB::table('patients')->insert([
                 "ward_id" => 3,
-                "name" => '川邊拓哉',
+                "name" => '山本三郎',
                 "birthday" => $faker->date()." ".$faker->time(),
                 "sex" => 1,
                 "room" => 101,
@@ -111,7 +111,33 @@ use Illuminate\Database\Seeder;
 
             DB::table('patients')->insert([
                 "ward_id" => 1,
-                "name" => 'Mayo Nakamura',
+                "name" => '高橋花子',
+                "birthday" => $faker->date()." ".$faker->time(),
+                "sex" => 2,
+                "room" => 201,
+                "hospitalization_date" => $faker->date()." ".$faker->time(),
+                "surgery_date" => $faker->date()." ".$faker->time(),
+                "memo" => 'マヨです',
+                "discharge_flg" => 0,
+                "created_at" => $faker->dateTime("now"),
+                "updated_at" => $faker->dateTime("now")
+            ]);
+            DB::table('patients')->insert([
+                "ward_id" => 1,
+                "name" => '吉田幸子',
+                "birthday" => $faker->date()." ".$faker->time(),
+                "sex" => 2,
+                "room" => 201,
+                "hospitalization_date" => $faker->date()." ".$faker->time(),
+                "surgery_date" => $faker->date()." ".$faker->time(),
+                "memo" => 'マヨです',
+                "discharge_flg" => 0,
+                "created_at" => $faker->dateTime("now"),
+                "updated_at" => $faker->dateTime("now")
+            ]);
+            DB::table('patients')->insert([
+                "ward_id" => 1,
+                "name" => '佐藤正子',
                 "birthday" => $faker->date()." ".$faker->time(),
                 "sex" => 2,
                 "room" => 201,

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Seeder;
 
             DB::table('users')->insert([
                 "ward_id" => 1,
-                "name" => '中村ダイスケ',
+                "name" => '看護師A',
                 "login_id" => 'nurse1',
                 "password" => bcrypt('nurse1'),
                 "admin_flg" => 0,
@@ -26,7 +26,7 @@ use Illuminate\Database\Seeder;
 
             DB::table('users')->insert([
                 "ward_id" => 1,
-                "name" => '山本篤',
+                "name" => '看護師B',
                 "login_id" => 'nurse2',
                 "password" => bcrypt('nurse2'),
                 "admin_flg" => 0,
@@ -36,7 +36,7 @@ use Illuminate\Database\Seeder;
 
             DB::table('users')->insert([
                 "ward_id" => 1,
-                "name" => '阿部 圭史',
+                "name" => '看護師C',
                 "login_id" => 'nurse3',
                 "password" =>  bcrypt('nurse3'),
                 "admin_flg" => 0,
@@ -75,7 +75,7 @@ use Illuminate\Database\Seeder;
 
             DB::table('users')->insert([
                 "ward_id" => 1,
-                "name" => 'みっしー',
+                "name" => '看護師D',
                 "login_id" => 'nurse7',
                 "password" => bcrypt('nurse7'),
                 "admin_flg" => 0,
@@ -85,7 +85,7 @@ use Illuminate\Database\Seeder;
 
             DB::table('users')->insert([
                 "ward_id" => 1,
-                "name" => 'いまっぱ',
+                "name" => '看護師E',
                 "login_id" => 'nurse8',
                 "password" => bcrypt('nurse8'),
                 "admin_flg" => 0,

--- a/resources/js/components/App.vue
+++ b/resources/js/components/App.vue
@@ -56,4 +56,22 @@ export default {
   margin-right:11px;
 }
 
+/* カレンダーの日付を非表示 */
+.v-calendar-daily_head-weekday {
+  display: none;
+}
+.v-calendar-daily_head-day-label {
+  display: none;
+}
+
+/* カレンダーのカテゴリーサイズ調整 */
+/* .v-calendar-category__column {
+  flex-shrink: 0 !important;
+  width: 200px !important;
+}
+.v-calendar-category__column-header {
+  flex-shrink: 0 !important;
+  width: 200px !important;
+} */
+
 </style>

--- a/resources/js/components/items/LeaderFooterComponent.vue
+++ b/resources/js/components/items/LeaderFooterComponent.vue
@@ -5,17 +5,17 @@
     color="blue lighten-1"
     fixed absolute
   >
-    <v-btn :to="{ name: 'ScheduleList' }">
+    <v-btn :to="{ name: 'ScheduleList',params:{team_id:this.$route.params.team_id} }">
       <span>スタッフスケジュール</span>
       <v-icon>mdi-history</v-icon>
     </v-btn>
 
-    <v-btn :to="{ name: 'TreatmentList' }">
+    <v-btn :to="{ name: 'TreatmentList' ,params:{team_id:this.$route.params.team_id}}">
       <span>処置一覧</span>
       <v-icon>mdi-account-group</v-icon>
     </v-btn>
 
-    <v-btn :to="{ name: 'PatientsList' }">
+    <v-btn :to="{ name: 'PatientsList' ,params:{team_id:this.$route.params.team_id}}">
       <span>患者一覧</span>
       <v-icon>mdi-account-group</v-icon>
     </v-btn>

--- a/resources/js/components/pages/leader/ScheduleList.vue
+++ b/resources/js/components/pages/leader/ScheduleList.vue
@@ -3,46 +3,13 @@
         <!-- ▼カレンダー -->
         <v-row class="fill-height">
             <v-col class="pa-0">
-                <v-sheet height="64">
-                    <v-toolbar flat color="white">
-                        <v-btn
-                            outlined
-                            class="mr-4"
-                            color="grey darken-2"
-                            @click="setToday"
-                            >Today</v-btn
-                        >
-                        <v-btn
-                            fab
-                            text
-                            small
-                            color="grey darken-2"
-                            @click="prev"
-                        >
-                            <v-icon small>mdi-chevron-left</v-icon>
-                        </v-btn>
-                        <v-btn
-                            fab
-                            text
-                            small
-                            color="grey darken-2"
-                            @click="next"
-                        >
-                            <v-icon small>mdi-chevron-right</v-icon>
-                        </v-btn>
-                        <v-toolbar-title v-if="$refs.calendar">
-                            {{ $refs.calendar.title }}
-                        </v-toolbar-title>
-                        <v-spacer></v-spacer>
-                    </v-toolbar>
-                </v-sheet>
-
                 <!-- ▼カレンダー設定 -->
-                <v-sheet height="600">
+                <v-sheet height="700">
                     <v-calendar
                         class="test"
                         ref="calendar"
                         v-model="focus"
+                        interval-height="100px"
                         color="primary"
                         type="category"
                         category-show-all
@@ -56,6 +23,11 @@
                         @mouseup:time="endDrag"
                         @mouseleave.native="cancelDrag"
                         @click:event="showEvent"
+                        @touchstart:event="startDrag"
+                        @touchstart:time-category="startTime"
+                        @touchmove:time-category="mouseMove"
+                        @touchendup:time="endDrag"
+                        @touchleace.native="cancelDrag"
                     >
                         <!-- nowライン設定 -->
                         <template #day-body="{ date, week }">
@@ -266,6 +238,18 @@
             </v-card>
         </transition>
         <!-- タスク作成時に開く詳細画面 ここまで-->
+        <!-- スケジュール追加ボタン -->
+        <v-btn
+            class="mx-2 regist_float_btn"
+            fab
+            dark
+            small
+            color="#62ABF8"
+            @click="registOpen = true"
+        >
+            <v-icon dark>mdi-plus</v-icon>
+        </v-btn>
+        <!-- スケジュール追加ボタンここまで -->
     </div>
 </template>
 <script>
@@ -936,4 +920,10 @@ export default {
     align-items: center;
 }
 /* スケジュール登録のスタイル ここまで */
+// 追加ボタン
+.regist_float_btn {
+    position: fixed;
+    bottom: 100px;
+    right: 20px;
+}
 </style>

--- a/resources/js/components/pages/staff/PatientSchedule.vue
+++ b/resources/js/components/pages/staff/PatientSchedule.vue
@@ -3,48 +3,15 @@
         <!-- ▼カレンダー -->
         <v-row class="fill-height">
             <v-col>
-                <v-sheet height="64">
-                    <v-toolbar flat color="white">
-                        <v-btn
-                            outlined
-                            class="mr-4"
-                            color="grey darken-2"
-                            @click="setToday"
-                            >Today</v-btn
-                        >
-                        <v-btn
-                            fab
-                            text
-                            small
-                            color="grey darken-2"
-                            @click="prev"
-                        >
-                            <v-icon small>mdi-chevron-left</v-icon>
-                        </v-btn>
-                        <v-btn
-                            fab
-                            text
-                            small
-                            color="grey darken-2"
-                            @click="next"
-                        >
-                            <v-icon small>mdi-chevron-right</v-icon>
-                        </v-btn>
-                        <v-toolbar-title v-if="$refs.calendar">
-                            {{ $refs.calendar.title }}
-                        </v-toolbar-title>
-                        <v-spacer></v-spacer>
-                    </v-toolbar>
-                </v-sheet>
-
                 <!-- ▼カレンダー設定 -->
-                <v-sheet height="600">
+                <v-sheet height="700">
                     <v-calendar
                         class="test"
                         ref="calendar"
                         v-model="focus"
                         color="primary"
                         type="category"
+                        interval-height="100px"
                         category-show-all
                         :categories="categories"
                         :events="events"
@@ -56,6 +23,10 @@
                         @mouseup:time="endDrag"
                         @mouseleave.native="cancelDrag"
                         @click:event="showEvent"
+                        @touchstart:event="startDrag"
+                        @touchstart:time="startTime"
+                        @touchmove:time="mouseMove"
+                        @touchendup:time="endDrag"
                     >
                         <!-- nowライン設定 -->
                         <template #day-body="{ date, week }">
@@ -67,7 +38,7 @@
                         </template>
                         <!-- nowライン設定ここまで -->
                         <!-- ドラック&ドロップ設定 -->
-                        <template #event="{ event, timed,eventSummary}">
+                        <template #event="{eventSummary}">
                             <div
                                 class="v-event-draggable"
                                 v-html="eventSummary()"
@@ -76,7 +47,7 @@
                                 v-if="timed"
                                 class="v-event-drag-bottom"
                                 @mousedown.stop="extendBottom(event)"
-              ></div>-->
+                            ></div>-->
                         </template>
                         <!-- ドラック&ドロップ設定ここまで -->
                     </v-calendar>
@@ -249,7 +220,7 @@ export default {
         // 【API】患者を取得
         fetchStaff: function() {
             axios
-                .get("/api/users_patients/get/all/")
+                .get(`/api/users_patients/get/all/${this.$route.params.schedule_id}`)
                 .then(res => {
                     this.staffs = res.data;
                     //   カレンダー表記用の配列に格納
@@ -399,29 +370,17 @@ export default {
                 this.selectedStaff = event.category;
                 // postデータ保持
                 this.selectedEvent = event;
+                console.log(event)
             }
         },
         startTime(tms) {
             const mouse = this.toTime(tms);
             if (this.dragEvent && this.dragTime === null) {
                 const start = this.dragEvent.start;
-
                 this.dragTime = mouse - start;
+            }else{
+
             }
-            //    else {
-            //     // イベント追加
-            //     this.createStart = this.roundTime(mouse);
-            //     this.createEvent = {
-            //       name: `Event`,
-            //       color: this.rndElement(this.colors),
-            //       start: this.createStart,
-            //       end: this.createStart,
-            //       timed: true,
-            //       // 追記
-            //       category: tms.category
-            //     };
-            //     this.events.push(this.createEvent);
-            //   }
         },
         // イベントを伸ばした後の処理
         extendBottom(event) {

--- a/resources/js/components/pages/staff/RegistSchedule.vue
+++ b/resources/js/components/pages/staff/RegistSchedule.vue
@@ -32,6 +32,7 @@
             v-model="focus"
             color="primary"
             type="day"
+            interval-height="100px"
             :events="events"
             :event-color="getEventColor"
             :event-ripple="false"

--- a/resources/js/components/pages/staff/StaffSchedule.vue
+++ b/resources/js/components/pages/staff/StaffSchedule.vue
@@ -39,7 +39,7 @@
                         </template>
                         <!-- nowライン設定ここまで -->
                         <!-- ドラック&ドロップ設定 -->
-                        <template #event="{ event, timed, eventSummary}">
+                        <template #event="{eventSummary}">
                             <div
                                 class="v-event-draggable"
                                 v-html="eventSummary()"
@@ -234,6 +234,18 @@
             </v-card>
         </transition>
         <!-- タスク作成時に開く詳細画面 ここまで-->
+        <!-- スケジュール追加ボタン -->
+        <v-btn
+        class="mx-2 regist_float_btn"
+        fab
+        dark
+        small
+        color="#62ABF8"
+        @click="registOpen = true"
+        >
+            <v-icon dark>mdi-plus</v-icon>
+        </v-btn>
+    <!-- スケジュール追加ボタンここまで -->
     </div>
     <!-- ここまで -->
 </template>
@@ -454,7 +466,7 @@ export default {
                     treatment_id: this.schedules[i].treatment.id,
                     name:
                         this.schedules[i].patient.name +
-                        " / " +
+                        " ： " +
                         this.schedules[i].treatment.name, // 処置の名前
                     start: unixStartdate, // 開始時刻
                     // start: this.schedules[i].start_date, // 開始時刻
@@ -729,9 +741,7 @@ body {
     user-select: none;
     -webkit-user-select: none;
 }
-// .test {
-//     position: relative;
-// }
+
 
 .v-event-drag-bottom {
     position: absolute;
@@ -877,5 +887,13 @@ body {
 .time_input >>> .vue__time-picker .dropdown ul li:not([disabled]).active:hover {
     background: #e6f4ff;
     color: #000;
+}
+
+
+// 追加ボタン
+.regist_float_btn {
+  position: fixed;
+  bottom: 100px;
+  right: 20px;
 }
 </style>

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -88,37 +88,37 @@ const routes = [
         meta: { title: "スタッフスケジュール" }
     },
     {
-        path: "/leader/patients-list",
+        path: "/leader/patients-list/:team_id",
         component: PatientsList,
         name: "PatientsList",
         meta: { title: "患者一覧" }
     },
     {
-        path: "/leader/regist-patient",
+        path: "/leader/regist-patient/:team_id",
         component: RegistPatient,
         name: "RegistPatient",
         meta: { title: "患者登録" }
     },
     {
-        path: "/leader/edit-patient/:patientId",
+        path: "/leader/edit-patient/:patientId/:team_id",
         component: EditPatient,
         name: "EditPatient",
         meta: { title: "患者詳細情報" }
     },
     {
-        path: "/leader/edit-treatment/:treatmentId",
+        path: "/leader/edit-treatment/:treatmentId/:team_id",
         component: EditTreatment,
         name: "EditTreatment",
         meta: { title: "処置編集" }
     },
     {
-        path: "/leader/regist-treatment",
+        path: "/leader/regist-treatment/:team_id",
         component: RegistTreatment,
         name: "RegistTreatment",
         meta: { title: "処置登録" }
     },
     {
-        path: "/leader/treatment-list",
+        path: "/leader/treatment-list/:team_id",
         component: TreatmentList,
         name: "TreatmentList",
         meta: { title: "処置一覧" }

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -85,7 +85,7 @@ const routes = [
         path: "/leader/schedule-list/:team_id",
         component: ScheduleList,
         name: "ScheduleList",
-        meta: { title: "スタッフスケジュール" }
+        meta: { title: "スケジュール" }
     },
     {
         path: "/leader/patients-list/:team_id",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <div class="login_right">
-        <a href="/admin/login" class="login_link">管理者ログイン</a>
+        <!-- <a href="/admin/login" class="login_link">管理者ログイン</a> -->
     </div>
     <div class="row justify-content-center">
         <div class="col-md-12">


### PR DESCRIPTION
※撮影用でいじっていた部分などがまとまっているので、一応コミットで分けてます

# やったこと
- 各カレンダーページのレイアウト調整
- シーダー変更
- リーダー画面のフッター修正（力技ですが...）

# やってないこと(Jootoにタスク化済)
- スマホ画面だと、D&DでDBへ保存されない
- カテゴリー表示のカレンダー（患者別と、リーダーのスタッフスケジュール）で、空間クリックでエラー吐いてます