### PR TITLE
カレンダーのタッチイベント修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-# /public/js/app.js
-# /public/css/app.css
-# /public/js/admin_app.js
-# /public/css/admin_app.css
+/public/js/app.js
+/public/css/app.css
+/public/js/admin_app.js
+/public/css/admin_app.css

--- a/resources/js/components/pages/leader/ScheduleList.vue
+++ b/resources/js/components/pages/leader/ScheduleList.vue
@@ -27,7 +27,7 @@
                         @touchstart:event="startDrag"
                         @touchstart:time-category="startTime"
                         @touchmove:time-category="mouseMove"
-                        @touchendup:time="endDrag"
+                        @touchend:time="endDrag"
                         @touchleace.native="cancelDrag"
                     >
                         <!-- nowライン設定 -->
@@ -40,7 +40,7 @@
                         </template>
                         <!-- nowライン設定ここまで -->
                         <!-- ドラック&ドロップ設定 -->
-                        <template #event="{ event, timed, eventSummary }">
+                        <template #event="{ eventSummary }">
                             <div
                                 class="v-event-draggable"
                                 v-html="eventSummary()"
@@ -177,9 +177,21 @@
                     </v-btn>
                 </v-card-actions>
                 <v-card-text class="pt-0">
-                    <p class="mb-0">
-                        登録するスタッフ:{{ registEvent.category }}
-                    </p>
+                    <div class="card_selectBox">
+                        <label>スタッフ</label>
+                        <div class="cp_ipselect cp_sl02">
+                            <select v-model="registEvent.user_id">
+                                <option disabled value>選択してください</option>
+                                <option
+                                    v-for="staff in staffs"
+                                    :value="staff.id"
+                                    :key="staff.id"
+                                >
+                                    {{ staff.name }}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
                     <div class="card_selectBox">
                         <label>患者</label>
                         <div class="cp_ipselect cp_sl02">
@@ -331,6 +343,7 @@ export default {
                 .get("/api/team_users/get/all/" + this.$route.params.team_id)
                 .then(res => {
                     this.staffs = res.data;
+                    console.log(this.staffs)
                     //   カレンダー表記用の配列に格納
                     this.categories = this.staffs.map(el => el.name);
                 })
@@ -405,7 +418,7 @@ export default {
         registTask: function() {
             // schedule_idを取得して格納
             const target = this.staffs.find(el => {
-                return el.name === this.registEvent.category;
+                return el.id === this.registEvent.user_id;
             });
             this.registEvent.schedule_id = target.schedule.id;
             //   時刻をDB登録用に整形

--- a/resources/js/components/pages/staff/PatientSchedule.vue
+++ b/resources/js/components/pages/staff/PatientSchedule.vue
@@ -27,7 +27,7 @@
                         @touchstart:event="startDrag"
                         @touchstart:time-category="startTime"
                         @touchmove:time-category="mouseMove"
-                        @touchendup:time="endDrag"
+                        @touchend:time="endDrag"
                     >
                         <!-- nowライン設定 -->
                         <template #day-body="{ date, week }">

--- a/resources/js/components/pages/staff/RegistSchedule.vue
+++ b/resources/js/components/pages/staff/RegistSchedule.vue
@@ -44,7 +44,7 @@
             @touchstart:event="startDrag"
             @touchstart:time="startTime"
             @touchmove:time="mouseMove"
-            @touchendup:time="endDrag"
+            @touchend:time="endDrag"
           >
             <!-- nowライン設定 -->
             <template #day-body="{ date, week }">

--- a/resources/js/components/pages/staff/StaffSchedule.vue
+++ b/resources/js/components/pages/staff/StaffSchedule.vue
@@ -24,7 +24,7 @@
                         @mousemove:time="mouseMove"
                         @touchmove:time="mouseMove"
                         @mouseup:time="endDrag"
-                        @touchendup:time="endDrag"
+                        @touchend:time="endDrag"
                         @mouseleave.native="cancelDrag"
                         @touchleave.native="cancelDrag"
                         @click:event="showEvent"


### PR DESCRIPTION
# やったこと
- カレンダーページのタッチイベントをスマホでも動くようにした
- リーダーによるスタッフのタスク追加処理をプルダウンに変更